### PR TITLE
refactor: change result to big endian

### DIFF
--- a/assembly/tally-phase.ts
+++ b/assembly/tally-phase.ts
@@ -25,7 +25,8 @@ export function tallyPhase(): void {
     const finalPrice = median(prices);
 
     // Report the successful result in the tally phase, encoding the result as bytes.
-    Process.success(Bytes.fromNumber(finalPrice));
+    // Encoding result with big endian to decode from EVM contracts.
+    Process.success(Bytes.fromNumber<u128>(finalPrice, true));
   } else {
     // If no valid prices were revealed, report an error indicating no consensus.
     Process.error(Bytes.fromUtf8String("No consensus among revealed results"));

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -49,8 +49,7 @@ describe("data request execution", () => {
     }]);
 
     expect(vmResult.exitCode).toBe(0);
-    // BigNumber.js is big endian
-    const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
+    const hex = Buffer.from(vmResult.result).toString('hex');
     const result = BigNumber(`0x${hex}`);
     expect(result).toEqual(BigNumber('2452300032'));
   });


### PR DESCRIPTION
Change result to big endian because it is more ergonomic to decode on EVM contracts. 