### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.0.0-rc.3" }
+seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.0.0-rc.4" }
 
 [profile.release-wasm]
 inherits = "release"


### PR DESCRIPTION
Bumped seda-sdk-rs dependency tag from rs-sdk/v1.0.0-rc.3 to rs-sdk/v1.0.0-rc.4

<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To enable other believers in SEDA, especially the vibecoders have a seamless experience getting into and deploying their oracle programs

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

The version rs-sdk/v1.0.0-rc.3 has the following issues while compiling
```
   Compiling seda-sdk-rs v1.0.0-rc.3 (https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.3#ff0fd02f)
error[E0433]: failed to resolve: use of undeclared crate or module `seda_sdk_rs`
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/http.rs:6:5
  |
6 | use seda_sdk_rs::bytes::{Bytes, ToBytes};
  |     ^^^^^^^^^^^ use of undeclared crate or module `seda_sdk_rs`

error[E0432]: unresolved import `seda_sdk_rs`
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/http.rs:2:5
  |
2 | use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions, HttpFetchMethod};
  |     ^^^^^^^^^^^ use of undeclared crate or module `seda_sdk_rs`

error[E0432]: unresolved imports `crate::http::HttpFetchResponse`, `crate::HttpFetchMethod`
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/proxy_http_fetch.rs:5:30
  |
5 |     http::{HttpFetchOptions, HttpFetchResponse},
  |                              ^^^^^^^^^^^^^^^^^ no `HttpFetchResponse` in `http`
...
8 |     HttpFetchMethod,
  |     ^^^^^^^^^^^^^^^ no `HttpFetchMethod` in the root

error[E0432]: unresolved import `http::HttpFetchResponse`
  --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/lib.rs:15:63
   |
15 | pub use http::{http_fetch, HttpFetchMethod, HttpFetchOptions, HttpFetchResponse};
   |                                                               ^^^^^^^^^^^^^^^^^ no `HttpFetchResponse` in `http`

error[E0603]: unresolved item import `HttpFetchOptions` is private
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/promise_actions.rs:3:18
  |
3 | use crate::http::HttpFetchOptions;
  |                  ^^^^^^^^^^^^^^^^ private unresolved item import
  |
note: the unresolved item import `HttpFetchOptions` is defined here
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/http.rs:2:51
  |
2 | use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions, HttpFetchMethod};
  |                                                   ^^^^^^^^^^^^^^^^

error[E0603]: unresolved item import `HttpFetchOptions` is private
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/proxy_http_fetch.rs:5:12
  |
5 |     http::{HttpFetchOptions, HttpFetchResponse},
  |            ^^^^^^^^^^^^^^^^ private unresolved item import
  |
note: the unresolved item import `HttpFetchOptions` is defined here
 --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/http.rs:2:51
  |
2 | use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions, HttpFetchMethod};
  |                                                   ^^^^^^^^^^^^^^^^

error[E0603]: unresolved item import `http_fetch` is private
  --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/lib.rs:15:16
   |
15 | pub use http::{http_fetch, HttpFetchMethod, HttpFetchOptions, HttpFetchResponse};
   |                ^^^^^^^^^^ private unresolved item import
   |
note: the unresolved item import `http_fetch` is defined here
  --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/http.rs:2:25
   |
2  | use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions, HttpFetchMethod};
   |                         ^^^^^^^^^^

error[E0603]: unresolved item import `HttpFetchMethod` is private
  --> /Users/user/.cargo/git/checkouts/seda-sdk-582f819b4b2ddca1/ff0fd02/libs/rs-sdk/sdk/src/lib.rs:15:28
   |
15 | pub use http::{http_fetch, HttpFetchMethod, HttpFetchOptions, HttpFetchResponse};
   |                            ^^^^^^^^^^^^^^^ private unresolved item import
```
I think these issues were resolved in the rs-sdk/v1.0.0-rc.4 version because once i bump the version, it works fine
## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->
The errors do not occur on the initial starter kit but once i make some changes involving more http calls, for some reason, it pops up anytime i run `bun run build`
But once i bump the version to rs-sdk/v1.0.0-rc.3 and run the same command, it runs perfectly fine


## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

(Link your related PRs and Issues here)
