### PR TITLE
Bump all SEDA dependencies to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "ctor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,7 +94,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 [[package]]
 name = "seda-sdk-macros"
 version = "0.1.0"
-source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.3#ff0fd02f2464d2435e9f7a53da0c94d77c4515f8"
+source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.5#ec043b2e44c5e1ccc76df895f9cdbabae94feef4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -72,10 +103,11 @@ dependencies = [
 
 [[package]]
 name = "seda-sdk-rs"
-version = "1.0.0-rc.3"
-source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.3#ff0fd02f2464d2435e9f7a53da0c94d77c4515f8"
+version = "1.0.0-rc.5"
+source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.5#ec043b2e44c5e1ccc76df895f9cdbabae94feef4"
 dependencies = [
  "anyhow",
+ "ctor",
  "hex",
  "seda-sdk-macros",
  "serde",
@@ -128,18 +160,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.0.0-rc.3" }
+seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.0.0-rc.5" }
 
 [profile.release-wasm]
 inherits = "release"

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,10 @@
     "": {
       "name": "seda-request-starter-kit",
       "dependencies": {
-        "@seda-protocol/vm": "^1.0.7",
+        "@seda-protocol/vm": "^1.0.12",
       },
       "devDependencies": {
-        "@seda-protocol/dev-tools": "^1.0.0-rc.9",
+        "@seda-protocol/dev-tools": "^1.0.0-rc.14",
         "@types/bun": "^1.2.13",
         "bignumber.js": "^9.3.0",
         "binaryen": "^123.0.0",
@@ -42,8 +42,6 @@
 
     "@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
 
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
-
     "@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "@noble/secp256k1": ["@noble/secp256k1@2.1.0", "", {}, "sha512-XLEQQNdablO0XZOIniFQimiXsZDNwaYgL96dZwC54Q30imSbAOFf3NKtepc+cXyuZf5Q1HCgbqgZ2UFFuHVcEw=="],
@@ -68,15 +66,15 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@seda-protocol/dev-tools": ["@seda-protocol/dev-tools@1.0.0-rc.9", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@seda-protocol/proto-messages": "1.0.0-rc.1", "@seda-protocol/utils": "^1.3.0", "@seda-protocol/vm": "^1.0.7", "big.js": "^6.2.1", "dotenv": "^16.3.1", "node-fetch": "^3.3.2", "node-gzip": "^1.1.2", "true-myth": "^7.3.0", "valibot": "^0.42.1" }, "bin": { "seda-sdk": "bin/index.js" } }, "sha512-AwAFmFcrwNvRCsHo8Px6Bnjslh94Lmx9AUXdjX7NOG7Gdpnx890z7+L4WR2GnC1PDfgmh+OAL6Qly6FGKB88sQ=="],
+    "@seda-protocol/dev-tools": ["@seda-protocol/dev-tools@1.0.0-rc.14", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@seda-protocol/proto-messages": "1.0.0-rc.1", "@seda-protocol/utils": "^1.3.0", "@seda-protocol/vm": "^1.0.12", "big.js": "^6.2.1", "dotenv": "^16.3.1", "node-fetch": "^3.3.2", "node-gzip": "^1.1.2", "true-myth": "^7.3.0", "valibot": "^0.42.1" }, "bin": { "seda-sdk": "bin/index.js" } }, "sha512-EiXE0JrdBJZPCaZr6V9jlhykD2Clv3OplHMlLEQXycERw6zILvZ7lM0vTOMaKpvNZxKz06+zcFb/el+hRU5gqQ=="],
 
     "@seda-protocol/proto-messages": ["@seda-protocol/proto-messages@1.0.0-rc.1", "", { "dependencies": { "protobufjs": "^7.4.0" } }, "sha512-hBcsq3VNOxbqk4UVkBXReDjG3W86pPz01abwoaBqYwWC7FBmJWqKUO1wCfL0qFbOjjOnsXXMxE+aJdnGWwh+3Q=="],
 
     "@seda-protocol/utils": ["@seda-protocol/utils@1.3.0", "", { "peerDependencies": { "true-myth": "^8.0.1", "valibot": "^0.42.1" } }, "sha512-6/2qt7+TUQcezWwGHB3QdJZLfd8cRzS58UpdbqzAtRmy4jsM7AR5bcKqNrIjNNBIB/rX29ObaLjT3JK3G3Khkg=="],
 
-    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.7", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-rENrRpLSB/rrN7QU85OgiZx08JRh+9rwyiug/sDtXhi88cJqM5RxStUZeuKwoPaENeJF7PEzGIFElhEK09FxGA=="],
+    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.12", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.1", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-Oh5TGpmp9r32mVMn5O/NJiG1Ssbl7mJXHwaoQV42ldWQvqD1L+T5RQt19ERaR2aIEQ6/T4TFJ4h1SzBT6R8eWw=="],
 
-    "@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.0", "", { "dependencies": { "buffer-pipe": "^0.0.5", "leb128": "^0.0.5", "warp-isomorphic": "^1.0.7" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-EA/xNeVG/yKiXw/zP+QL0q/Oq7cpee2ydpfmfOXMVgU0emEX2aHuSv1lHCNuw4vNVuN7sjzEUXKwUlkAAmBvaA=="],
+    "@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.1", "", { "dependencies": { "leb128": "^0.0.5" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-Mx5CR76dIFgBVCJlBJ50MEuOYfGez/w2DWkSj4tIUVz1cSNbhYTd29+/0gQjrM056mDqfpJDg03VKjcCrlehDg=="],
 
     "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
 
@@ -102,9 +100,7 @@
 
     "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
 
-    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "buffer-pipe": ["buffer-pipe@0.0.5", "", { "dependencies": { "safe-buffer": "^5.2.0" } }, "sha512-a6kQxHM27rLrDpVFCKk9iirHKQU2fukg/j3XqIIOoc1rT/W5kp+KsIQmff6dJ7I3ErxmAasetarkeSG1iqGpkA=="],
+    "buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
 
     "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
@@ -145,8 +141,6 @@
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -192,8 +186,6 @@
 
     "typescript": ["typescript@4.9.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="],
 
-    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "uwasi": ["uwasi@1.4.1", "", {}, "sha512-QOT8tBsSwG7dm99Ry4X2gqsEEq4B6Q3eMSyazMQw7fd6XwBKPvBnxgpAksDRLZBMIp+F1wChhKPon20HQK6i0Q=="],
@@ -201,8 +193,6 @@
     "valibot": ["valibot@0.42.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw=="],
 
     "wabt": ["wabt@1.0.37", "", { "bin": { "wasm2c": "bin/wasm2c", "wasm2wat": "bin/wasm2wat", "wat2wasm": "bin/wat2wasm", "wasm-stats": "bin/wasm-stats", "wasm-strip": "bin/wasm-strip", "wasm-interp": "bin/wasm-interp", "wasm-objdump": "bin/wasm-objdump", "wasm-validate": "bin/wasm-validate", "wasm-decompile": "bin/wasm-decompile" } }, "sha512-2B/TH4ppwtlkUosLtuIimKsTVnqM8aoXxYHnu/WOxiSqa+CGoZXmG+pQyfDQjEKIAc7GqFlJsuCKuK8rIPL1sg=="],
-
-    "warp-isomorphic": ["warp-isomorphic@1.0.7", "", { "dependencies": { "buffer": "^6.0.3", "undici": "^5.19.1" } }, "sha512-fXHbUXwdYqPm9fRPz8mjv5ndPco09aMQuTe4kXfymzOq8V6F3DLsg9cIafxvjms9/mc6eijzkLBJ63yjEENEjA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -219,8 +209,6 @@
     "@seda-protocol/utils/true-myth": ["true-myth@8.5.2", "", {}, "sha512-xkORnYI949ingIpqlRQzqMCQJifCWWoDb7l+TC6dg8IaMjhF4gIGjT420rZ7368/oTPdH3hO2wCOhHS4UTcgyQ=="],
 
     "elliptic/bn.js": ["bn.js@4.12.1", "", {}, "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="],
-
-    "leb128/buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
 
     "@confio/ics23/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seda-starter-kit",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "description": "Starter kit for building and deploying SEDA oracle data requests with EVM integration",
   "type": "module",
   "scripts": {
@@ -20,13 +20,13 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@seda-protocol/dev-tools": "^1.0.0-rc.9",
+    "@seda-protocol/dev-tools": "^1.0.0-rc.14",
     "@types/bun": "^1.2.13",
     "bignumber.js": "^9.3.0",
     "binaryen": "^123.0.0",
     "wabt": "^1.0.37"
   },
   "dependencies": {
-    "@seda-protocol/vm": "^1.0.7"
+    "@seda-protocol/vm": "^1.0.12"
   }
 }


### PR DESCRIPTION
## Motivation

This includes a speedup for large oracle programs, user customisable HTTP timeouts, and removing path information from error traces in the Rust SDK by default.

## Explanation of Changes

N.A.

## Testing

I can still build and test the oracle program.

## Related PRs and Issues

N.A.