### PR TITLE
feat: adding foundry starter  + readmes

### DIFF
--- a/.github/workflows/evm-foundry.yml
+++ b/.github/workflows/evm-foundry.yml
@@ -1,0 +1,42 @@
+name: EVM Foundry
+
+on:
+  push:
+    branches: [main]
+    paths: ['integrations/evm-foundry/**']
+  pull_request:
+    branches: [main]
+    paths: ['integrations/evm-foundry/**']
+  workflow_dispatch:
+
+jobs:
+  evm-foundry-build-and-test:
+    name: EVM Foundry
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations/evm-foundry
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Install dependencies
+        run: forge install
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Run checks
+        run: |
+          forge fmt --check
+          forge lint
+
+      - name: Run tests
+        run: forge test -vvv

--- a/.github/workflows/evm-hardhat.yml
+++ b/.github/workflows/evm-hardhat.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/evm-hardhat.yml
+++ b/.github/workflows/evm-hardhat.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  evm-hardhat-build-and-test:
+    name: EVM Hardhat
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  op-build-and-test:
+    name: Oracle Program
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "integrations/evm-foundry/lib/forge-std"]
+	path = integrations/evm-foundry/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "integrations/evm-foundry/lib/openzeppelin-contracts"]
+	path = integrations/evm-foundry/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "integrations/evm-foundry/lib/seda-evm-contracts"]
+	path = integrations/evm-foundry/lib/seda-evm-contracts
+	url = https://github.com/sedaprotocol/seda-evm-contracts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "const-hex"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ctor"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,8 +124,9 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "seda-sdk-macros"
-version = "0.1.0"
-source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.6#1b10022691e57fb0248680c8b1375572d1395f79"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0438b5216cd73921ddb4b7021f0d2b3e23a95ba7d63071adb4610966cf7d6542"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -103,10 +135,11 @@ dependencies = [
 
 [[package]]
 name = "seda-sdk-rs"
-version = "1.0.0-rc.6"
-source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.0.0-rc.6#1b10022691e57fb0248680c8b1375572d1395f79"
+version = "1.1.0"
+source = "git+https://github.com/sedaprotocol/seda-sdk?tag=rs-sdk%2Fv1.1.0#9cee65245f0d07fc829557fb960fb70365f918a6"
 dependencies = [
  "anyhow",
+ "const-hex",
  "ctor",
  "hex",
  "seda-sdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.0.0-rc.6" }
+seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag = "rs-sdk/v1.1.0" }
 
 [profile.release-wasm]
 inherits = "release"

--- a/bun.lock
+++ b/bun.lock
@@ -4,13 +4,13 @@
     "": {
       "name": "seda-request-starter-kit",
       "dependencies": {
-        "@seda-protocol/vm": "^1.0.14",
+        "@seda-protocol/vm": "^1.1.0",
       },
       "devDependencies": {
-        "@seda-protocol/dev-tools": "^1.0.1",
-        "@types/bun": "^1.2.13",
-        "bignumber.js": "^9.3.0",
-        "binaryen": "^123.0.0",
+        "@seda-protocol/dev-tools": "^1.0.3",
+        "@types/bun": "^1.2.22",
+        "bignumber.js": "^9.3.1",
+        "binaryen": "^124.0.0",
         "wabt": "^1.0.37",
       },
     },
@@ -66,21 +66,23 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@seda-protocol/dev-tools": ["@seda-protocol/dev-tools@1.0.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@seda-protocol/proto-messages": "1.0.0", "@seda-protocol/utils": "^1.3.0", "@seda-protocol/vm": "^1.0.15", "big.js": "^6.2.1", "dotenv": "^16.3.1", "fetch-cookie": "^3.1.0", "node-fetch": "^3.3.2", "node-gzip": "^1.1.2", "true-myth": "^7.3.0", "valibot": "^0.42.1" }, "bin": { "seda-sdk": "bin/index.js" } }, "sha512-eJ2aZlcmIcq2AFsI88IPZnavAK19PxYTnz+uPSOYzV+Z4nYymQpHpxIecg+MErZMcWgk8Wfyyp/YuREkrwX4hQ=="],
+    "@seda-protocol/dev-tools": ["@seda-protocol/dev-tools@1.0.3", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@seda-protocol/proto-messages": "1.0.0", "@seda-protocol/utils": "^1.3.0", "@seda-protocol/vm": "^1.1.0", "big.js": "^6.2.1", "dotenv": "^16.3.1", "fetch-cookie": "^3.1.0", "node-fetch": "^3.3.2", "node-gzip": "^1.1.2", "secp256k1": "^5.0.1", "true-myth": "^7.3.0", "valibot": "^0.42.1" }, "bin": { "seda-sdk": "bin/index.js" } }, "sha512-/rQJc4un8gWJcKr+v4CdVY/bLqet0rOjg1btTNV+9hrDj/oOoVhuR46CnYJxBtd2ywPVMydoyEpaujPn2YnOug=="],
 
     "@seda-protocol/proto-messages": ["@seda-protocol/proto-messages@1.0.0", "", { "dependencies": { "protobufjs": "^7.4.0" } }, "sha512-3okvhaoTsFgIKKYAvURil0VQBrNfPPq/cdQ6BeQ0eKf0irGAm9pJmSyEwNG5xxnTOLDJdhSeGY9o1x1Shfgh1w=="],
 
     "@seda-protocol/utils": ["@seda-protocol/utils@1.3.0", "", { "peerDependencies": { "true-myth": "^8.0.1", "valibot": "^0.42.1" } }, "sha512-6/2qt7+TUQcezWwGHB3QdJZLfd8cRzS58UpdbqzAtRmy4jsM7AR5bcKqNrIjNNBIB/rX29ObaLjT3JK3G3Khkg=="],
 
-    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.14", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.1", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-hJ0g/CoJR7WhGMR+lWhF1x8NV6XtYlIW2nAHWxonCJWTwezwgjGODYNMJrvbtG0+rQKxWB6zT3yESnQgOH2xAw=="],
+    "@seda-protocol/vm": ["@seda-protocol/vm@1.1.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.1", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-Jcr/ZP1e87BCVsep+nqdFVJmvbGXnSwR06KF/8GsNtZ01lMO1p2+Hzo3uj9SHYWdIJxKMBtREVNX6aRUsL08rA=="],
 
     "@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.1", "", { "dependencies": { "leb128": "^0.0.5" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-Mx5CR76dIFgBVCJlBJ50MEuOYfGez/w2DWkSj4tIUVz1cSNbhYTd29+/0gQjrM056mDqfpJDg03VKjcCrlehDg=="],
 
-    "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
+    "@types/bun": ["@types/bun@1.2.22", "", { "dependencies": { "bun-types": "1.2.22" } }, "sha512-5A/KrKos2ZcN0c6ljRSOa1fYIyCKhZfIVYeuyb4snnvomnpFqC0tTsEkdqNxbAgExV384OETQ//WAjl3XbYqQA=="],
 
     "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
 
     "@types/node": ["@types/node@22.12.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA=="],
+
+    "@types/react": ["@types/react@19.1.13", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -92,9 +94,9 @@
 
     "big.js": ["big.js@6.2.2", "", {}, "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="],
 
-    "bignumber.js": ["bignumber.js@9.3.0", "", {}, "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA=="],
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
-    "binaryen": ["binaryen@123.0.0", "", { "bin": { "wasm-as": "bin/wasm-as", "wasm2js": "bin/wasm2js", "wasm-dis": "bin/wasm-dis", "wasm-opt": "bin/wasm-opt", "wasm-merge": "bin/wasm-merge", "wasm-shell": "bin/wasm-shell", "wasm-reduce": "bin/wasm-reduce", "wasm-metadce": "bin/wasm-metadce", "wasm-ctor-eval": "bin/wasm-ctor-eval" } }, "sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw=="],
+    "binaryen": ["binaryen@124.0.0", "", { "bin": { "wasm-as": "bin/wasm-as", "wasm2js": "bin/wasm2js", "wasm-dis": "bin/wasm-dis", "wasm-opt": "bin/wasm-opt", "wasm-merge": "bin/wasm-merge", "wasm-shell": "bin/wasm-shell", "wasm-reduce": "bin/wasm-reduce", "wasm-metadce": "bin/wasm-metadce", "wasm-ctor-eval": "bin/wasm-ctor-eval" } }, "sha512-RUv9bWl9C4kwjOmi4yA/yjW/w+YMtoEEpTFtI1nIl1m+1AGWRvxirGgd8AeqUnEB65HcsjZJ+WAIsGuVBwDxwA=="],
 
     "bn.js": ["bn.js@5.2.1", "", {}, "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="],
 
@@ -102,11 +104,13 @@
 
     "buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
 
-    "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
+    "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "cosmjs-types": ["cosmjs-types@0.9.0", "", {}, "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -164,9 +168,13 @@
 
     "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
 
+    "node-addon-api": ["node-addon-api@5.1.0", "", {}, "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-gzip": ["node-gzip@1.1.2", "", {}, "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="],
 
@@ -181,6 +189,8 @@
     "readonly-date": ["readonly-date@1.0.0", "", {}, "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "secp256k1": ["secp256k1@5.0.1", "", { "dependencies": { "elliptic": "^6.5.7", "node-addon-api": "^5.0.0", "node-gyp-build": "^4.2.0" } }, "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
 
@@ -215,8 +225,6 @@
     "@confio/ics23/protobufjs": ["protobufjs@6.11.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw=="],
 
     "@cosmjs/crypto/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
-
-    "@seda-protocol/dev-tools/@seda-protocol/vm": ["@seda-protocol/vm@1.0.15", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.1", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-u8o92uYDefwQjj3twVmkGvB/m/sF7DhjhaVuLM0Bka4590gUqPJC28jVLKDfrooUxQaW11Z+GRviv8RmxBhqQw=="],
 
     "@seda-protocol/utils/true-myth": ["true-myth@8.5.2", "", {}, "sha512-xkORnYI949ingIpqlRQzqMCQJifCWWoDb7l+TC6dg8IaMjhF4gIGjT420rZ7368/oTPdH3hO2wCOhHS4UTcgyQ=="],
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,147 @@
+# SEDA Integrations
+
+This directory contains integration examples that demonstrate how to connect your SEDA Oracle Programs to different blockchain networks.
+
+## Overview
+
+The SEDA Request Starter Kit includes two main components:
+
+1. **Oracle Program** (in the root directory) - A Rust-based WASM program that fetches and processes data
+2. **Destination Smart Contracts** (in this directory) - Smart contracts that interact with your deployed Oracle Program
+
+## Available Integrations
+
+### EVM (Ethereum Virtual Machine)
+
+| Framework | Description | Directory |
+|-----------|-------------|-----------|
+| **Hardhat** | TypeScript-based development environment with comprehensive tooling | [`evm-hardhat/`](./evm-hardhat/) |
+| **Foundry** | Rust-based toolkit with advanced testing and deployment capabilities | [`evm-foundry/`](./evm-foundry/) |
+
+Both integrations feature a **PriceFeed contract** that serves as an example contract that uses SEDA data, demonstrating how to:
+- Create data requests on the SEDA network
+- Retrieve and process oracle results
+- Handle fees and gas optimization
+
+## Getting Started
+
+### Step 1: Deploy Your Oracle Program
+
+Before using any integration, you must first build and deploy an Oracle Program to the SEDA network:
+
+```bash
+# From the root directory
+bun run build
+bun run deploy
+```
+
+This will give you an `ORACLE_PROGRAM_ID` that you'll need for the destination contracts.
+
+### Step 2: Choose Your Integration
+
+Select the integration that best fits your development preferences:
+
+- **Choose Hardhat** if you prefer TypeScript, comprehensive tooling, and detailed documentation
+- **Choose Foundry** if you prefer Rust-based tooling, advanced testing, and gas optimization
+
+### Step 3: Deploy Destination Contracts
+
+Each integration includes deployment scripts for the example PriceFeed contract. The destination contracts must be deployed to your target EVM network (e.g., Base Sepolia, Ethereum, etc.).
+
+## Important Notes
+
+> [!IMPORTANT]
+> The **PriceFeed contract is an example** designed for educational purposes. It demonstrates basic SEDA integration patterns but should be modified for production use.
+
+## Understanding the Architecture
+
+### Oracle Program vs Destination Contract
+
+- **Oracle Program** (Rust/WASM): Defines what data to fetch, how to process it, and what format to return
+- **Destination Contract** (Solidity): Defines how to request data and how to use the results
+
+### Data Flow
+
+1. **Destination Contract** calls `transmit()` with input parameters
+2. **SEDA Network** executes the Oracle Program with those inputs
+3. **Oracle Program** fetches and processes data, returns result in defined format
+4. **Destination Contract** calls `latestAnswer()` to retrieve the processed result
+
+## Customization Guide
+
+The PriceFeed contract is designed to be modified for your specific use case:
+
+### What's Hardcoded in the EVM Contract (for simplicity)
+
+You can make these configurable:
+
+- **Gas limits**: `execGasLimit` and `tallyGasLimit` (currently hardcoded to 50B and 20B)
+- **Replication factor**: Number of executor nodes (currently hardcoded to 1)
+- **Fees**: Request, result, and batch fees (can be made configurable)
+- **Contract logic**: Access controls, validation, error handling
+
+### What's Defined by the Oracle Program
+
+The Oracle Program supports different trading pairs out of the box:
+
+- **Input format**: Any trading pair in "SYMBOL-SYMBOL" format (e.g., "ETH-USDC", "BTC-USDT")
+- **Data source**: Uses Binance API (can be changed to any API)
+- **Processing logic**: Fetches price, converts to integer with 6 decimal precision
+- **Output format**: Returns price as `uint128` (16 bytes, little-endian)
+- **Error handling**: Reports errors back to SEDA network
+
+### Example Modifications
+
+#### Making EVM Contract Parameters Configurable
+
+```solidity
+// Make gas limits configurable
+function transmit(
+    uint256 requestFee, 
+    uint256 resultFee, 
+    uint256 batchFee,
+    uint64 execGasLimit,
+    uint64 tallyGasLimit
+) external payable returns (bytes32) {
+    // Use parameters instead of hardcoded values
+}
+
+// Add access control
+modifier onlyOwner() {
+    require(msg.sender == owner, "Not authorized");
+    _;
+}
+```
+
+#### Using Different Trading Pairs
+
+The Oracle Program handles any "SYMBOL-SYMBOL" format. Modify the EVM contract to request different data:
+
+```solidity
+function transmitForPair(string memory pair) external payable returns (bytes32) {
+    bytes memory execInputs = abi.encode(pair); // "BTC-USDT", "ETH-USDC", etc.
+    // ... rest of transmit logic
+}
+```
+
+#### Changing Data Sources or Output Formats
+
+Modify the Oracle Program for different APIs or output formats:
+
+```rust
+// In src/execution_phase.rs
+let response = http_fetch(
+    format!("https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies={}", 
+            symbol_a, symbol_b),
+    None,
+);
+
+let result = format!("{{\"price\":\"{}\",\"pair\":\"{}\"}}", price, dr_inputs_raw);
+Process::success(result.as_bytes());
+```
+
+## Resources
+
+- [SEDA Protocol Documentation](https://docs.seda.xyz)
+- [Building Oracle Programs Guide](https://docs.seda.xyz/home/for-developers/building-an-oracle-program)
+- [SEDA SDK Documentation](https://github.com/sedaprotocol/seda-sdk)

--- a/integrations/evm-foundry/.env.example
+++ b/integrations/evm-foundry/.env.example
@@ -29,16 +29,6 @@ CORE_ADDRESS=0x...
 PRICEFEED_ADDRESS=0x...
 
 # =============================================================================
-# TRANSACTION SIGNING
-# =============================================================================
-
-# Option 1: Use private key (recommended for production)
-EVM_PRIVATE_KEY=0x...
-
-# Option 2: Use mnemonic (fallback if EVM_PRIVATE_KEY not set)
-# MNEMONIC="your twelve word mnemonic phrase here"
-
-# =============================================================================
 # REQUEST FEES (optional - defaults to 0)
 # =============================================================================
 

--- a/integrations/evm-foundry/.env.example
+++ b/integrations/evm-foundry/.env.example
@@ -1,0 +1,76 @@
+# =============================================================================
+# SEDA Foundry Integration - Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in your values
+
+# =============================================================================
+# REQUIRED VARIABLES
+# =============================================================================
+
+# Oracle Program ID (required for all operations)
+# This is the ID of the WASM binary on the SEDA network
+ORACLE_PROGRAM_ID=0x...
+
+# =============================================================================
+# NETWORK CONFIGURATION
+# =============================================================================
+
+# SEDA Core Contract Address (optional)
+# If not set, will deploy MockSedaCore for testing
+# Addresses available at: https://docs.seda.xyz/home/for-developers/prover-deployments
+CORE_ADDRESS=0x...
+
+# =============================================================================
+# DEPLOYED CONTRACT ADDRESSES
+# =============================================================================
+
+# PriceFeed Contract Address (required for transmit/latest operations)
+# Set this after deploying with: forge script script/Deploy.s.sol:Deploy
+PRICEFEED_ADDRESS=0x...
+
+# =============================================================================
+# TRANSACTION SIGNING
+# =============================================================================
+
+# Option 1: Use private key (recommended for production)
+EVM_PRIVATE_KEY=0x...
+
+# Option 2: Use mnemonic (fallback if EVM_PRIVATE_KEY not set)
+# MNEMONIC="your twelve word mnemonic phrase here"
+
+# =============================================================================
+# REQUEST FEES (optional - defaults to 0)
+# =============================================================================
+
+# Fee for creating the request (in wei)
+REQUEST_FEE=0
+
+# Fee for processing the result (in wei)  
+RESULT_FEE=0
+
+# Fee for batch processing (in wei)
+BATCH_FEE=0
+
+# =============================================================================
+# NETWORK RPC ENDPOINTS (configured in foundry.toml)
+# =============================================================================
+# Available networks:
+# - baseSepolia: https://sepolia.base.org
+# - gnosisChiado: https://rpc.chiadochain.net  
+# - superseedSepolia: https://sepolia.superseed.xyz
+# - hyperliquidPurrsec: https://rpc.hyperliquid-testnet.xyz/evm
+
+# =============================================================================
+# USAGE EXAMPLES
+# =============================================================================
+# 
+# 1. Deploy PriceFeed:
+#    forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast
+#
+# 2. Transmit request:
+#    forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast
+#
+# 3. Get latest price:
+#    forge script script/Latest.s.sol:Latest --rpc-url baseSepolia
+#
+# =============================================================================

--- a/integrations/evm-foundry/.github/workflows/test.yml
+++ b/integrations/evm-foundry/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: |
+          forge --version
+
+      - name: Run Forge fmt
+        run: |
+          forge fmt --check
+        id: fmt
+
+      - name: Run Forge build
+        run: |
+          forge build --sizes
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/integrations/evm-foundry/.gitignore
+++ b/integrations/evm-foundry/.gitignore
@@ -1,0 +1,15 @@
+# Dependencies
+lib/
+
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+broadcast/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/integrations/evm-foundry/README.md
+++ b/integrations/evm-foundry/README.md
@@ -1,0 +1,144 @@
+# SEDA Foundry Integration
+
+[![Foundry](https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg?style=flat&logo=foundry)](https://book.getfoundry.sh/)
+[![Solidity](https://img.shields.io/badge/Solidity-^0.8.28-blue.svg?style=flat&logo=solidity)](https://soliditylang.org/)
+
+A starter kit for connecting SEDA Oracle Programs to EVM-compatible blockchains using Foundry. This integration features a **PriceFeed contract** that demonstrates how to create and retrieve data requests from the SEDA network.
+
+> [!IMPORTANT]
+> The **PriceFeed contract is an example** designed for educational purposes. It demonstrates basic SEDA integration patterns but should be modified for production use.
+
+## Prerequisites
+
+Before using this integration, you must:
+
+1. **Deploy an Oracle Program** to the SEDA network (see the [main README](../../README.md))
+2. **Get your Oracle Program ID** from the deployment
+3. **Set up your environment** with the required variables
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+# Install Foundry dependencies
+forge install
+
+# Build contracts
+forge build
+
+# Run tests
+forge test
+```
+
+### 2. Environment Setup
+
+Create a `.env` file with the required variables:
+
+```bash
+# Copy the example file
+cp .env.example .env
+```
+
+#### Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ORACLE_PROGRAM_ID` | SEDA Oracle Program ID (bytes32) | `0x...` |
+
+#### Optional Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CORE_ADDRESS` | SEDA Core contract address | Deploy MockSedaCore |
+| `PRICEFEED_ADDRESS` | Deployed PriceFeed address | None |
+| `EVM_PRIVATE_KEY` | Private key for signing | Use mnemonic |
+| `REQUEST_FEE` | Request fee in wei | `0` |
+| `RESULT_FEE` | Result fee in wei | `0` |
+| `BATCH_FEE` | Batch fee in wei | `0` |
+
+### 3. Deploy the PriceFeed Contract
+
+> [!IMPORTANT]
+> You must deploy the PriceFeed contract before you can create data requests. This is a destination contract that interacts with your deployed Oracle Program.
+
+```bash
+# Deploy to Base Sepolia
+forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast --verify
+
+# Deploy with custom SEDA Core address
+CORE_ADDRESS=0x... forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast
+```
+
+### 4. Interact with Your Contract
+
+**Create a Data Request:**
+```bash
+# Transmit with default fees
+PRICEFEED_ADDRESS=0x... forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast
+
+# Transmit with custom fees
+PRICEFEED_ADDRESS=0x... REQUEST_FEE=1000000000000000 RESULT_FEE=2000000000000000 BATCH_FEE=500000000000000 forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast
+```
+
+**Fetch the Latest Result:**
+```bash
+PRICEFEED_ADDRESS=0x... forge script script/Latest.s.sol:Latest --rpc-url baseSepolia
+```
+
+## Understanding the Integration
+
+### Oracle Program vs Destination Contract
+
+- **Oracle Program** (Rust/WASM): Fetches data from external sources and processes it
+- **Destination Contract** (Solidity): Requests data from the Oracle Program and uses the results
+
+The PriceFeed contract is a **destination contract** that:
+1. Creates data requests on the SEDA network using your Oracle Program
+2. Retrieves processed results from the Oracle Program
+3. Makes the data available to other smart contracts
+
+### Example Flow
+
+1. **Deploy Oracle Program** → Get `ORACLE_PROGRAM_ID`
+2. **Deploy PriceFeed Contract** → Uses the `ORACLE_PROGRAM_ID`
+3. **Call `transmit()`** → Creates a data request on SEDA network
+4. **Call `latestAnswer()`** → Retrieves the processed result
+
+## Testing
+
+```bash
+# Run all tests
+forge test
+
+# Run with gas reporting
+forge test --gas-report
+
+# Run specific test
+forge test --match-test test_ReturnCorrectLatestAnswerWithConsensus
+```
+
+## Development
+
+```bash
+# Format code
+forge fmt
+
+# Lint code
+forge lint
+
+# Generate gas snapshots
+forge snapshot
+```
+
+## Next Steps
+
+For advanced topics, different oracle programs, and customization ideas, see the [main integrations README](../README.md#whats-next).
+
+## Resources
+
+- [SEDA Protocol Documentation](https://docs.seda.xyz)
+- [Foundry Documentation](https://book.getfoundry.sh)
+- [Solidity Documentation](https://docs.soliditylang.org)
+- [Building Oracle Programs Guide](https://docs.seda.xyz/home/for-developers/building-an-oracle-program)
+- [SEDA SDK Documentation](https://github.com/sedaprotocol/seda-sdk)

--- a/integrations/evm-foundry/README.md
+++ b/integrations/evm-foundry/README.md
@@ -40,6 +40,10 @@ Create a `.env` file with the required variables:
 cp .env.example .env
 ```
 
+Set up your account to use for broadcasting transactions, check the [Foundry documentation](https://getfoundry.sh/guides/best-practices/key-management) for more best practices on how to manage your keys.
+
+In this README we will assume a wallet called "CAST_WALLET" has been imported into `cast` using the `cast wallet import --private-key 0x... CAST_WALLET` command.
+
 #### Required Variables
 
 | Variable | Description | Example |
@@ -52,7 +56,6 @@ cp .env.example .env
 |----------|-------------|---------|
 | `CORE_ADDRESS` | SEDA Core contract address | Deploy MockSedaCore |
 | `PRICEFEED_ADDRESS` | Deployed PriceFeed address | None |
-| `EVM_PRIVATE_KEY` | Private key for signing | Use mnemonic |
 | `REQUEST_FEE` | Request fee in wei | `0` |
 | `RESULT_FEE` | Result fee in wei | `0` |
 | `BATCH_FEE` | Batch fee in wei | `0` |
@@ -64,10 +67,10 @@ cp .env.example .env
 
 ```bash
 # Deploy to Base Sepolia
-forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast --verify
+forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast --verify --account CAST_WALLET --sender cast_wallet_address
 
 # Deploy with custom SEDA Core address
-CORE_ADDRESS=0x... forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast
+CORE_ADDRESS=0x... forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast --account CAST_WALLET --sender cast_wallet_address
 ```
 
 ### 4. Interact with Your Contract
@@ -75,10 +78,10 @@ CORE_ADDRESS=0x... forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia
 **Create a Data Request:**
 ```bash
 # Transmit with default fees
-PRICEFEED_ADDRESS=0x... forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast
+PRICEFEED_ADDRESS=0x... forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast --account CAST_WALLET --sender cast_wallet_address
 
 # Transmit with custom fees
-PRICEFEED_ADDRESS=0x... REQUEST_FEE=1000000000000000 RESULT_FEE=2000000000000000 BATCH_FEE=500000000000000 forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast
+PRICEFEED_ADDRESS=0x... REQUEST_FEE=1000000000000000 RESULT_FEE=2000000000000000 BATCH_FEE=500000000000000 forge script script/Transmit.s.sol:Transmit --rpc-url baseSepolia --broadcast --account CAST_WALLET --sender cast_wallet_address
 ```
 
 **Fetch the Latest Result:**

--- a/integrations/evm-foundry/foundry.lock
+++ b/integrations/evm-foundry/foundry.lock
@@ -1,0 +1,23 @@
+{
+  "integrations/evm-foundry/lib/forge-std": {
+    "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+  },
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.10.0",
+      "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+    }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.4.0",
+      "rev": "c64a1edb67b6e3f4a15cca8909c9482ad33a02b0"
+    }
+  },
+  "lib/seda-evm-contracts": {
+    "tag": {
+      "name": "v1.0.0",
+      "rev": "4c90901413df6e1c59129a3551cea2c1f7c7f86e"
+    }
+  }
+}

--- a/integrations/evm-foundry/foundry.toml
+++ b/integrations/evm-foundry/foundry.toml
@@ -1,0 +1,29 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+script = "script"
+remappings = [
+    "@seda-protocol/evm/=lib/seda-evm-contracts/",
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/"
+]
+
+[fmt]
+  bracket_spacing = true
+  int_types = "long"
+  line_length = 120
+  multiline_func_header = "all"
+  number_underscore = "thousands"
+  quote_style = "double"
+  tab_width = 4
+  wrap_comments = true
+
+[etherscan]
+  mainnet = { key = "${API_KEY_ETHERSCAN}" }
+
+[rpc_endpoints]
+base = "https://mainnet.base.org"
+baseSepolia = "https://sepolia.base.org"
+gnosisChiado = "https://rpc.chiadochain.net"
+superseedSepolia = "https://sepolia.superseed.xyz"
+hyperliquidPurrsec = "https://rpc.hyperliquid-testnet.xyz/evm"

--- a/integrations/evm-foundry/foundry.toml
+++ b/integrations/evm-foundry/foundry.toml
@@ -4,22 +4,22 @@ out = "out"
 libs = ["lib"]
 script = "script"
 remappings = [
-    "@seda-protocol/evm/=lib/seda-evm-contracts/",
-    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/"
+    "forge-std/=lib/forge-std/src/",
+    "@seda-protocol/evm/=lib/seda-evm-contracts/"
 ]
 
 [fmt]
-  bracket_spacing = true
-  int_types = "long"
-  line_length = 120
-  multiline_func_header = "all"
-  number_underscore = "thousands"
-  quote_style = "double"
-  tab_width = 4
-  wrap_comments = true
+bracket_spacing = true
+int_types = "long"
+line_length = 120
+multiline_func_header = "all"
+number_underscore = "thousands"
+quote_style = "double"
+tab_width = 4
+wrap_comments = true
 
 [etherscan]
-  mainnet = { key = "${API_KEY_ETHERSCAN}" }
+mainnet = { key = "${API_KEY_ETHERSCAN}" }
 
 [rpc_endpoints]
 base = "https://mainnet.base.org"

--- a/integrations/evm-foundry/script/BaseScript.s.sol
+++ b/integrations/evm-foundry/script/BaseScript.s.sol
@@ -4,26 +4,8 @@ pragma solidity >=0.8.28 <0.9.0;
 import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
-    /// @dev Included to enable compilation of the script without a $ETH_PRIVATE_KEY environment variable.
-    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
-
-    /// @dev The address of the transaction broadcaster.
-    address internal broadcaster;
-
-    /// @dev Initializes the transaction broadcaster:
-    /// - If $EVM_PRIVATE_KEY is defined, derive address from it.
-    /// - Otherwise, derive from $MNEMONIC (or test mnemonic if not set).
-    constructor() {
-        try vm.envUint("EVM_PRIVATE_KEY") returns (uint256 privateKey) {
-            broadcaster = vm.addr(privateKey);
-        } catch {
-            string memory mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
-            (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
-        }
-    }
-
     modifier broadcast() {
-        vm.startBroadcast(broadcaster);
+        vm.startBroadcast();
         _;
         vm.stopBroadcast();
     }

--- a/integrations/evm-foundry/script/BaseScript.s.sol
+++ b/integrations/evm-foundry/script/BaseScript.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.28 <0.9.0;
+
+import { Script } from "forge-std/Script.sol";
+
+abstract contract BaseScript is Script {
+    /// @dev Included to enable compilation of the script without a $ETH_PRIVATE_KEY environment variable.
+    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
+
+    /// @dev The address of the transaction broadcaster.
+    address internal broadcaster;
+
+    /// @dev Initializes the transaction broadcaster:
+    /// - If $EVM_PRIVATE_KEY is defined, derive address from it.
+    /// - Otherwise, derive from $MNEMONIC (or test mnemonic if not set).
+    constructor() {
+        try vm.envUint("EVM_PRIVATE_KEY") returns (uint256 privateKey) {
+            broadcaster = vm.addr(privateKey);
+        } catch {
+            string memory mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
+            (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        }
+    }
+
+    modifier broadcast() {
+        vm.startBroadcast(broadcaster);
+        _;
+        vm.stopBroadcast();
+    }
+}

--- a/integrations/evm-foundry/script/Deploy.s.sol
+++ b/integrations/evm-foundry/script/Deploy.s.sol
@@ -11,7 +11,6 @@ contract Deploy is BaseScript {
         // ENV:
         // - ORACLE_PROGRAM_ID (required): bytes32
         // - CORE_ADDRESS (optional): if set, use it; else deploy MockSedaCore
-        // - EVM_PRIVATE_KEY or MNEMONIC for transaction signing
 
         // Get Oracle Program ID (same for all networks)
         bytes32 opId = vm.envBytes32("ORACLE_PROGRAM_ID");

--- a/integrations/evm-foundry/script/Deploy.s.sol
+++ b/integrations/evm-foundry/script/Deploy.s.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.28 <0.9.0;
+
+import { console2 } from "forge-std/console2.sol";
+import { BaseScript } from "./BaseScript.s.sol";
+import { PriceFeed } from "../src/PriceFeed.sol";
+import { MockSedaCore } from "@seda-protocol/evm/contracts/mocks/MockSedaCore.sol";
+
+contract Deploy is BaseScript {
+    function run() external broadcast {
+        // ENV:
+        // - ORACLE_PROGRAM_ID (required): bytes32
+        // - CORE_ADDRESS (optional): if set, use it; else deploy MockSedaCore
+        // - EVM_PRIVATE_KEY or MNEMONIC for transaction signing
+
+        // Get Oracle Program ID (same for all networks)
+        bytes32 opId = vm.envBytes32("ORACLE_PROGRAM_ID");
+
+        // Auto-detect network and get SEDA Core address
+        uint256 chainId = block.chainid;
+        address core = getSedaCoreAddress(chainId);
+
+        // If CORE_ADDRESS provided via env, use it; else use network default
+        if (vm.envOr("CORE_ADDRESS", bytes("")).length > 0) {
+            core = vm.envAddress("CORE_ADDRESS");
+            console2.log("Using env CORE_ADDRESS:", core);
+        } else {
+            console2.log("Using network default CORE_ADDRESS:", core);
+        }
+
+        // Deploy MockSedaCore if no core address available
+        if (core == address(0)) {
+            MockSedaCore mock = new MockSedaCore();
+            core = address(mock);
+            console2.log("Deployed MockSedaCore:", core);
+        }
+
+        PriceFeed feed = new PriceFeed(core, opId);
+        console2.log("Deployed PriceFeed:", address(feed));
+        console2.log("Chain ID:", chainId);
+        console2.logBytes32(opId);
+    }
+
+    function getSedaCoreAddress(uint256 chainId) internal pure returns (address) {
+        if (chainId == 8453) {
+            // Base Mainnet
+            return 0xDF1fb5ACe711B16D90FC45776fF1bF02CEBc245D;
+        } else if (chainId == 84_532) {
+            // Base Sepolia
+            return 0xffDB1d9bBE4D56780143428450c4C2058061E6F3;
+        } else if (chainId == 10_200) {
+            // Gnosis Chiado
+            return 0xbe2ace709959C121759d553cACf7e6532C25a3aA;
+        } else if (chainId == 12_345) {
+            // Superseed Sepolia (example chain ID)
+            return 0xE08989FB730E072689b4885c2a62AE5f1fc787F2;
+        } else if (chainId == 999) {
+            // Hyperliquid Purrsec (example chain ID)
+            return 0x23c01fe3C1b7409A98bBd39a7c9e5C2263C64b59;
+        } else if (chainId == 31_337) {
+            // Hardhat
+            // Will deploy MockSedaCore
+            return address(0);
+        } else {
+            revert("Unknown core address for network");
+        }
+    }
+}

--- a/integrations/evm-foundry/script/Latest.s.sol
+++ b/integrations/evm-foundry/script/Latest.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.28 <0.9.0;
+
+import { console2 } from "forge-std/console2.sol";
+import { BaseScript } from "./BaseScript.s.sol";
+import { PriceFeed } from "../src/PriceFeed.sol";
+
+contract Latest is BaseScript {
+    function run() external view {
+        if (!vm.envExists("PRICEFEED_ADDRESS")) {
+            revert("PRICEFEED_ADDRESS environment variable not set");
+        }
+
+        address feedAddr = vm.envAddress("PRICEFEED_ADDRESS");
+        PriceFeed feed = PriceFeed(feedAddr);
+
+        // Get the latest price
+        uint128 price = feed.latestAnswer();
+
+        console2.log("Latest ETH-USDC price:", price);
+        console2.log("PriceFeed address:", feedAddr);
+        console2.log("Request ID:", vm.toString(feed.requestId()));
+    }
+}

--- a/integrations/evm-foundry/script/Transmit.s.sol
+++ b/integrations/evm-foundry/script/Transmit.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.28 <0.9.0;
+
+import { console2 } from "forge-std/console2.sol";
+import { BaseScript } from "./BaseScript.s.sol";
+import { PriceFeed } from "../src/PriceFeed.sol";
+
+contract Transmit is BaseScript {
+    function run() external broadcast {
+        if (!vm.envExists("PRICEFEED_ADDRESS")) {
+            revert("PRICEFEED_ADDRESS environment variable not set");
+        }
+        address feedAddr = vm.envAddress("PRICEFEED_ADDRESS");
+        uint256 requestFee = vm.envOr("REQUEST_FEE", uint256(0));
+        uint256 resultFee = vm.envOr("RESULT_FEE", uint256(0));
+        uint256 batchFee = vm.envOr("BATCH_FEE", uint256(0));
+        uint256 valueWei = requestFee + resultFee + batchFee;
+
+        bytes32 reqId = PriceFeed(feedAddr).transmit{ value: valueWei }(requestFee, resultFee, batchFee);
+
+        console2.log("requestId: 0x%x", uint256(reqId));
+    }
+}

--- a/integrations/evm-foundry/src/PriceFeed.sol
+++ b/integrations/evm-foundry/src/PriceFeed.sol
@@ -1,0 +1,84 @@
+// src/PriceFeed.sol
+// SPDX-License-Identifier: MIT
+/**
+ * NOTICE: This is an example contract to demonstrate SEDA network functionality.
+ * It is for educational purposes only and should not be used in production.
+ */
+pragma solidity 0.8.28;
+
+import { ISedaCore } from "@seda-protocol/evm/contracts/interfaces/ISedaCore.sol";
+import { SedaDataTypes } from "@seda-protocol/evm/contracts/libraries/SedaDataTypes.sol";
+
+/**
+ * @title PriceFeed
+ * @author Open Oracle Association
+ * @notice An example showing how to create and interact with SEDA network requests.
+ * @dev This contract demonstrates basic SEDA request creation and result fetching.
+ */
+contract PriceFeed {
+    /// @notice Instance of the SedaCore contract
+    ISedaCore public immutable SEDA_CORE;
+
+    /// @notice ID of the request WASM binary on the SEDA network
+    bytes32 public immutable ORACLE_PROGRAM_ID;
+
+    /// @notice ID of the most recent request
+    bytes32 public requestId;
+
+    /// @notice Thrown when trying to fetch results before any request is transmitted
+    error RequestNotTransmitted();
+
+    /**
+     * @notice Sets up the contract with SEDA network parameters
+     * @param _sedaCoreAddress Address of the SedaCore contract
+     * @param _oracleProgramId ID of the WASM binary for handling requests
+     */
+    constructor(address _sedaCoreAddress, bytes32 _oracleProgramId) {
+        SEDA_CORE = ISedaCore(_sedaCoreAddress);
+        ORACLE_PROGRAM_ID = _oracleProgramId;
+    }
+
+    /**
+     * @notice Creates a new ETH-USDC price request on the SEDA network
+     * @dev Demonstrates how to structure and send a request to SEDA
+     * @param requestFee The fee for the request
+     * @param resultFee The fee for the result
+     * @param batchFee The fee for the batch
+     * @return The ID of the created request
+     */
+    function transmit(uint256 requestFee, uint256 resultFee, uint256 batchFee) external payable returns (bytes32) {
+        SedaDataTypes.RequestInputs memory inputs = SedaDataTypes.RequestInputs(
+            ORACLE_PROGRAM_ID, // execProgramId (Execution WASM binary ID)
+            ORACLE_PROGRAM_ID, // tallyProgramId (same as execProgramId in this example)
+            2000, // gasPrice (SEDA tokens per gas unit)
+            50_000_000_000_000, // execGasLimit (within uint64 range)
+            20_000_000_000_000, // tallyGasLimit (within uint64 range)
+            1, // replicationFactor (number of required DR executors)
+            bytes("eth-usdc"), // execInputs (Inputs for Execution WASM)
+            hex"00", // tallyInputs
+            hex"00", // consensusFilter (set to `None`)
+            abi.encodePacked(block.number) // memo (Additional public info)
+        );
+
+        // Pass the msg.value as fees to the SEDA core
+        requestId = SEDA_CORE.postRequest{ value: msg.value }(inputs, requestFee, resultFee, batchFee);
+        return requestId;
+    }
+
+    /**
+     * @notice Retrieves the result of the latest request
+     * @dev Shows how to fetch and interpret SEDA request results
+     * @return The price as uint128, or 0 if no consensus was reached
+     */
+    function latestAnswer() public view returns (uint128) {
+        if (requestId == bytes32(0)) revert RequestNotTransmitted();
+
+        SedaDataTypes.Result memory result = SEDA_CORE.getResult(requestId);
+
+        if (result.consensus && result.exitCode == 0) {
+            return uint128(bytes16(result.result));
+        }
+
+        return 0;
+    }
+}

--- a/integrations/evm-foundry/test/PriceFeed.t.sol
+++ b/integrations/evm-foundry/test/PriceFeed.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+import { PriceFeed } from "../src/PriceFeed.sol";
+import { MockSedaCore } from "@seda-protocol/evm/contracts/mocks/MockSedaCore.sol";
+import { SedaDataTypes } from "@seda-protocol/evm/contracts/libraries/SedaDataTypes.sol";
+
+contract PriceFeedTest is Test {
+    PriceFeed public priceFeed;
+    MockSedaCore public mockCore;
+    bytes32 public constant ORACLE_PROGRAM_ID = bytes32(0);
+
+    function setUp() public {
+        // Deploy MockSedaCore
+        mockCore = new MockSedaCore();
+
+        // Deploy PriceFeed contract
+        priceFeed = new PriceFeed(address(mockCore), ORACLE_PROGRAM_ID);
+    }
+
+    /**
+     * Test Case 1: No transmission before `latestAnswer`
+     * Ensure that calling latestAnswer without transmitting a data request first reverts.
+     */
+    function test_RevertIfDataRequestNotTransmitted() public {
+        // Attempting to call latestAnswer without a transmission should revert
+        vm.expectRevert(PriceFeed.RequestNotTransmitted.selector);
+        priceFeed.latestAnswer();
+    }
+
+    /**
+     * Test Case 2: No data result found
+     * Ensure that calling latestAnswer after transmission but without setting a data result reverts.
+     */
+    function test_RevertIfDataResultNotFound() public {
+        // Transmit the data request (but no result set)
+        priceFeed.transmit(0, 0, 0);
+
+        // latestAnswer should revert due to no data result being set
+        vm.expectRevert();
+        priceFeed.latestAnswer();
+    }
+
+    /**
+     * Test Case 3: Return correct `latestAnswer` with consensus (true)
+     * Verify that latestAnswer returns the correct value when consensus is reached.
+     */
+    function test_ReturnCorrectLatestAnswerWithConsensus() public {
+        // Transmit a data request
+        priceFeed.transmit(0, 0, 0);
+        bytes32 dataRequestId = priceFeed.requestId();
+
+        // Set a data result with consensus in the contract
+        uint128 resultValue = 245_230_000; // Mock value
+        bytes memory resultBytes = abi.encodePacked(resultValue);
+
+        SedaDataTypes.Result memory result = SedaDataTypes.Result({
+            version: "0.0.1",
+            drId: dataRequestId,
+            consensus: true,
+            exitCode: 0,
+            result: resultBytes,
+            blockHeight: 0,
+            blockTimestamp: uint64(block.timestamp + 3600),
+            gasUsed: 0,
+            paybackAddress: abi.encodePacked(address(0)),
+            sedaPayload: abi.encodePacked(bytes32(0))
+        });
+
+        mockCore.postResult(result, 0, new bytes32[](0));
+
+        // latestAnswer should return the expected result when consensus is reached
+        uint128 latestAnswer = priceFeed.latestAnswer();
+        assertEq(latestAnswer, resultValue);
+    }
+
+    /**
+     * Test Case 4: Return zero if no consensus reached
+     * Ensure that latestAnswer returns 0 when no consensus is reached.
+     */
+    function test_ReturnZeroIfNoConsensus() public {
+        // Transmit a data request
+        priceFeed.transmit(0, 0, 0);
+        bytes32 dataRequestId = priceFeed.requestId();
+
+        // Set a data result without consensus (false)
+        uint128 resultValue = 100; // Mock value
+        bytes memory resultBytes = abi.encodePacked(resultValue);
+
+        SedaDataTypes.Result memory result = SedaDataTypes.Result({
+            version: "0.0.1",
+            drId: dataRequestId,
+            consensus: false,
+            exitCode: 0,
+            result: resultBytes,
+            blockHeight: 0,
+            blockTimestamp: uint64(block.timestamp + 3600),
+            gasUsed: 0,
+            paybackAddress: abi.encodePacked(address(0)),
+            sedaPayload: abi.encodePacked(bytes32(0))
+        });
+
+        mockCore.postResult(result, 0, new bytes32[](0));
+
+        // latestAnswer should return 0 since no consensus was reached
+        uint128 latestAnswer = priceFeed.latestAnswer();
+        assertEq(latestAnswer, 0);
+    }
+
+    /**
+     * Test Case 5: Successful transmission
+     * Ensure that a data request is correctly transmitted and the request ID is valid.
+     */
+    function test_SuccessfulTransmission() public {
+        // Assert data request id is zero initially
+        bytes32 dataRequestId = priceFeed.requestId();
+        assertEq(dataRequestId, bytes32(0));
+
+        // Call the transmit function
+        priceFeed.transmit(0, 0, 0);
+
+        // Check that the data request ID is valid and stored correctly
+        dataRequestId = priceFeed.requestId();
+        assertTrue(dataRequestId != bytes32(0));
+    }
+
+    /**
+     * Test Case 6: Test with different fee values
+     * Ensure that transmit works with various fee combinations.
+     */
+    function test_TransmitWithDifferentFees() public {
+        uint256 requestFee = 1000;
+        uint256 resultFee = 2000;
+        uint256 batchFee = 500;
+        uint256 totalFee = requestFee + resultFee + batchFee;
+
+        // Call transmit with specific fees and send ETH
+        bytes32 dataRequestId = priceFeed.transmit{ value: totalFee }(requestFee, resultFee, batchFee);
+
+        // Verify the request ID is set
+        assertTrue(dataRequestId != bytes32(0));
+        assertEq(priceFeed.requestId(), dataRequestId);
+    }
+
+    /**
+     * Test Case 7: Test with exit code != 0
+     * Ensure that latestAnswer returns 0 when exit code is not 0.
+     */
+    function test_ReturnZeroWithNonZeroExitCode() public {
+        // Transmit a data request
+        priceFeed.transmit(0, 0, 0);
+        bytes32 dataRequestId = priceFeed.requestId();
+
+        // Set a data result with consensus but non-zero exit code
+        uint128 resultValue = 12_345;
+        bytes memory resultBytes = abi.encodePacked(resultValue);
+
+        SedaDataTypes.Result memory result = SedaDataTypes.Result({
+            version: "0.0.1",
+            drId: dataRequestId,
+            consensus: true,
+            exitCode: 1, // Non-zero exit code
+            result: resultBytes,
+            blockHeight: 0,
+            blockTimestamp: uint64(block.timestamp + 3600),
+            gasUsed: 0,
+            paybackAddress: abi.encodePacked(address(0)),
+            sedaPayload: abi.encodePacked(bytes32(0))
+        });
+
+        mockCore.postResult(result, 0, new bytes32[](0));
+
+        // latestAnswer should return 0 since exit code is not 0
+        uint128 latestAnswer = priceFeed.latestAnswer();
+        assertEq(latestAnswer, 0);
+    }
+}

--- a/integrations/evm-hardhat/.env.example
+++ b/integrations/evm-hardhat/.env.example
@@ -1,3 +1,80 @@
-ORACLE_PROGRAM_ID=YOUR_ORACLE_PROGRAM_ID
-EVM_PRIVATE_KEY=YOUR_EVM_PRIVATE_KEY
-BASE_SEPOLIA_ETHERSCAN_API_KEY=YOUR_BASESCAN_API_KEY
+# =============================================================================
+# SEDA Hardhat Integration - Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in your values
+
+# =============================================================================
+# REQUIRED VARIABLES
+# =============================================================================
+
+# Oracle Program ID (required for all operations)
+# This is the ID of the WASM binary on the SEDA network
+ORACLE_PROGRAM_ID=0x...
+
+# =============================================================================
+# TRANSACTION SIGNING
+# =============================================================================
+
+# Private key for transaction signing (required for non-local networks)
+# Format: 0x followed by 64 hex characters
+EVM_PRIVATE_KEY=0x...
+
+# =============================================================================
+# BLOCK EXPLORER API KEYS (optional)
+# =============================================================================
+
+# Base Sepolia Etherscan API Key (for contract verification)
+# Get your API key from: https://basescan.org/apis
+BASE_SEPOLIA_ETHERSCAN_API_KEY=your_api_key_here
+
+# =============================================================================
+# NETWORK CONFIGURATION
+# =============================================================================
+# SEDA Core addresses are automatically configured per network in seda.config.ts
+# Available networks:
+# - base: Mainnet Base
+# - baseSepolia: Testnet Base Sepolia  
+# - superseedSepolia: Superseed Sepolia
+# - chiado: Gnosis Chiado
+# - hyperliquidPurrsec: Hyperliquid Purrsec
+
+# =============================================================================
+# DEPLOYED CONTRACT ADDRESSES
+# =============================================================================
+# Contract addresses are automatically saved to deployments/addresses.json
+# after successful deployment. No manual configuration needed.
+
+# =============================================================================
+# USAGE EXAMPLES
+# =============================================================================
+# 
+# 1. Deploy PriceFeed to Base Sepolia:
+#    bunx hardhat pricefeed deploy --network baseSepolia --verify
+#
+# 2. Transmit data request:
+#    bunx hardhat pricefeed transmit --network baseSepolia
+#
+# 3. Get latest price:
+#    bunx hardhat pricefeed latest --network baseSepolia
+#
+# 4. Deploy with custom parameters:
+#    bunx hardhat pricefeed deploy --network baseSepolia --coreaddress 0x... --oracleprogramid 0x...
+#
+# 5. Transmit with custom fees (in ETH):
+#    bunx hardhat pricefeed transmit --network baseSepolia --requestfee 0.001 --resultfee 0.002 --batchfee 0.0005
+#
+# =============================================================================
+# LOCAL DEVELOPMENT
+# =============================================================================
+# 
+# For local testing (hardhat network):
+# - No EVM_PRIVATE_KEY needed
+# - MockSedaCore will be deployed automatically
+# - ZeroHash will be used as Oracle Program ID
+#
+# Example:
+# bunx hardhat pricefeed deploy --network hardhat
+# bunx hardhat pricefeed transmit --network hardhat
+# bunx hardhat pricefeed latest --network hardhat
+#
+# =============================================================================

--- a/integrations/evm-hardhat/README.md
+++ b/integrations/evm-hardhat/README.md
@@ -29,7 +29,7 @@ This project follows the structure of a typical Hardhat project:
 
 ## Environment Variables
 
-Configure the .env file with the necessary variables. Here is an example .env file:
+Create a `.env` file in the project root with the necessary variables:
 
 ```
 ORACLE_PROGRAM_ID=YOUR_ORACLE_PROGRAM_ID
@@ -39,6 +39,8 @@ BASE_SEPOLIA_ETHERSCAN_API_KEY=YOUR_BASESCAN_API_KEY
 
 > [!CAUTION]
 > You must provide a valid EVM private key in your .env file to deploy and interact with contracts. Never share or commit your private key. Use a dedicated testing account with minimal funds.
+
+Alternatively, this project also supports `dotenvx` for environment variable management with built-in secret encryption. See the [dotenvx documentation](https://dotenvx.com) for usage details.
 
 ## Compiling and Testing the Contracts
 

--- a/integrations/evm-hardhat/README.md
+++ b/integrations/evm-hardhat/README.md
@@ -8,32 +8,40 @@
   SEDA Hardhat Integration
 </h1>
 
-This integration is built on a minimal Hardhat boilerplate, focusing on simplicity to showcase how to interact with the SEDA network. It features a sample consumer contract (PriceFeed) that interacts with the SEDA protocol through a Prover Contract, demonstrating how to create and retrieve data requests on the network.
+A TypeScript-based starter kit for connecting SEDA Oracle Programs to EVM-compatible blockchains using Hardhat. This integration features a **PriceFeed contract** that demonstrates how to create and retrieve data requests from the SEDA network.
 
-## Getting Started
+> [!IMPORTANT]
+> The **PriceFeed contract is an example** designed for educational purposes. It demonstrates basic SEDA integration patterns but should be modified for production use.
 
-Navigate to the `evm-hardhat` directory and install the dependencies:
+## Prerequisites
+
+Before using this integration, you must:s
+
+1. **Deploy an Oracle Program** to the SEDA network (see the [main README](../../README.md))
+2. **Get your Oracle Program ID** from the deployment
+3. **Set up your environment** with the required variables
+
+## Quick Start
+
+### 1. Install Dependencies
 
 ```sh
 cd integrations/evm-hardhat
 bun install
 ```
 
-### Project Structure
+### 2. Environment Setup
 
-This project follows the structure of a typical Hardhat project:
+Create a `.env` file with the required variables:
 
-- **contracts/**: Contains the Solidity contracts including PriceFeed.
-- **tasks/**: Hardhat tasks for interacting with the PriceFeed contract.
-- **test/**: Test files for the contracts.
-
-## Environment Variables
-
-Create a `.env` file in the project root with the necessary variables:
-
-```
+```bash
+# Required: Your deployed Oracle Program ID
 ORACLE_PROGRAM_ID=YOUR_ORACLE_PROGRAM_ID
+
+# Required: Your EVM private key for deployment
 EVM_PRIVATE_KEY=YOUR_EVM_PRIVATE_KEY
+
+# Optional: For contract verification
 BASE_SEPOLIA_ETHERSCAN_API_KEY=YOUR_BASESCAN_API_KEY
 ```
 
@@ -42,56 +50,96 @@ BASE_SEPOLIA_ETHERSCAN_API_KEY=YOUR_BASESCAN_API_KEY
 
 Alternatively, this project also supports `dotenvx` for environment variable management with built-in secret encryption. See the [dotenvx documentation](https://dotenvx.com) for usage details.
 
-## Compiling and Testing the Contracts
+### 3. Deploy the PriceFeed Contract
 
-Compile your contracts and run tests to ensure everything works correctly:
-
-```sh
-bun run compile
-bun run test
-```
-
-## Deploying the Contracts
-
-For your pricefeed you'll first need to build and deploy an Oracle Program to the SEDA network. In the root of this repository you'll find and example and the tools to create and deploy your own Oracle Programs. After deployment, you'll receive an ID that identifies your program on the network. This ID should be set in your `.env` file as `ORACLE_PROGRAM_ID`.
-
-Deploy the `PriceFeed` contract using dedicated Hardhat tasks:
+> [!IMPORTANT]
+> You must deploy the PriceFeed contract before you can create data requests. This is a destination contract that interacts with your deployed Oracle Program.
 
 ```sh
+# Deploy to Base Sepolia
 bunx hardhat pricefeed deploy --network baseSepolia --verify
+
+# Deploy with custom parameters
+bunx hardhat pricefeed deploy --oracle-program-id YOUR_ORACLE_PROGRAM_ID --core-address YOUR_CORE_ADDRESS --force
 ```
 
 To deploy to a specific network, use the `--network` flag followed by the network name (e.g. baseSepolia, goerli). You can also add the `--verify` flag to automatically verify the contract's source code on the network's block explorer after deployment.
 
-By default, the deployment uses environment variables defined in your `.env` file, but you can override these with command-line parameters:
-
-```sh
-bunx hardhat pricefeed deploy --oracle-program-id YOUR_ORACLE_PROGRAM_ID --core-address YOUR_CORE_ADDRESS --force
-```
+By default, the deployment uses environment variables defined in your `.env` file, but you can override these with command-line parameters.
 
 > [!NOTE]
 > The project includes a `seda.config.ts` file that contains SEDA-specific configurations including pre-configured core addresses for supported networks. You can modify this file to add support for additional networks or customize existing configurations.
 
-## Interacting with Deployed Contracts
+### 4. Interact with Your Contract
 
-Use Hardhat tasks specifically designed for interacting with the PriceFeed contract.
-
-**Transmit a Data Request**: Calls the transmit function on PriceFeed to trigger a data request post on the SEDA network.
-
+**Create a Data Request:**
 ```sh
 bunx hardhat pricefeed transmit --network baseSepolia
 ```
 
-**Fetch Latest Answer**: Calls the latestAnswer function on PriceFeed to get the result of the data request.
-
+**Fetch the Latest Result:**
 ```sh
 bunx hardhat pricefeed latest --network baseSepolia
 ```
 
-## Additional Resources
+## Project Structure
 
-- [**SEDA Protocol Documentation**](https://docs.seda.xyz): Learn more about how to build on the SEDA network and interact with data requests.
-- [**Hardhat Documentation**](https://hardhat.org/docs): Understand how to use Hardhat for developing, deploying, and testing your contracts.
+This project follows the structure of a typical Hardhat project:
+
+- **contracts/**: Contains the Solidity contracts including PriceFeed.
+- **tasks/**: Hardhat tasks for interacting with the PriceFeed contract.
+- **test/**: Test files for the contracts.
+- **seda.config.ts**: SEDA network configurations with deployed Core Addresses.
+
+## Understanding the Integration
+
+### Oracle Program vs Destination Contract
+
+- **Oracle Program** (Rust/WASM): Fetches data from external sources and processes it
+- **Destination Contract** (Solidity): Requests data from the Oracle Program and uses the results
+
+The PriceFeed contract is a **destination contract** that:
+1. Creates data requests on the SEDA network using your Oracle Program
+2. Retrieves processed results from the Oracle Program
+3. Makes the data available to other smart contracts
+
+### Example Flow
+
+1. **Deploy Oracle Program** → Get `ORACLE_PROGRAM_ID`
+2. **Deploy PriceFeed Contract** → Uses the `ORACLE_PROGRAM_ID`
+3. **Call `transmit()`** → Creates a data request on SEDA network
+4. **Call `latestAnswer()`** → Retrieves the processed result
+
+## Testing
+
+```sh
+# Compile contracts
+bun run compile
+
+# Run tests
+bun run test
+```
+
+## Development
+
+```sh
+# Format code
+bun run format
+
+# Lint code
+bun run lint
+```
+
+## Next Steps
+
+For advanced topics, different oracle programs, and customization ideas, see the [main integrations README](../README.md#whats-next).
+
+## Resources
+
+- [SEDA Protocol Documentation](https://docs.seda.xyz)
+- [Hardhat Documentation](https://hardhat.org/docs)
+- [Building Oracle Programs Guide](https://docs.seda.xyz/home/for-developers/building-an-oracle-program)
+- [SEDA SDK Documentation](https://github.com/sedaprotocol/seda-sdk)
 
 ## License
 

--- a/integrations/evm-hardhat/bun.lock
+++ b/integrations/evm-hardhat/bun.lock
@@ -8,8 +8,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.1.2",
+        "@dotenvx/dotenvx": "^1.49.1",
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
-        "dotenv": "^17.2.1",
         "hardhat": "^2.26.1",
         "prettier": "^3.6.2",
         "prettier-plugin-solidity": "^2.1.0",
@@ -46,6 +46,10 @@
     "@bytecodealliance/preview2-shim": ["@bytecodealliance/preview2-shim@0.17.2", "", {}, "sha512-mNm/lblgES8UkVle8rGImXOz4TtL3eU3inHay/7TVchkKrb/lgcVvTK0+VAw8p5zQ0rgQsXm1j5dOlAAd+MeoA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.49.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-LQ8cem3RU/mI2iz5Sy+ypnhfhVge3bc9tsLJg5rdf7j7u1RRTfmmSdLwSjeYI7sL9ToN7rgFkOGSBJqaBT+gSQ=="],
+
+    "@ecies/ciphers": ["@ecies/ciphers@0.2.4", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w=="],
 
     "@ethereumjs/rlp": ["@ethereumjs/rlp@5.0.2", "", { "bin": { "rlp": "bin/rlp.cjs" } }, "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA=="],
 
@@ -123,9 +127,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@noble/secp256k1": ["@noble/secp256k1@1.7.1", "", {}, "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="],
 
@@ -417,7 +423,7 @@
 
     "command-line-usage": ["command-line-usage@6.1.3", "", { "dependencies": { "array-back": "^4.0.2", "chalk": "^2.4.2", "table-layout": "^1.0.2", "typical": "^5.2.0" } }, "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw=="],
 
-    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -473,6 +479,8 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "eciesjs": ["eciesjs@0.4.15", "", { "dependencies": { "@ecies/ciphers": "^0.2.3", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0" } }, "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA=="],
+
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -514,6 +522,8 @@
     "ethjs-unit": ["ethjs-unit@0.1.6", "", { "dependencies": { "bn.js": "4.11.6", "number-to-bn": "1.7.0" } }, "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw=="],
 
     "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
+
+    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -621,6 +631,8 @@
 
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
     "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -659,11 +671,13 @@
 
     "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
     "jackspeak": ["jackspeak@4.0.2", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw=="],
 
@@ -739,6 +753,8 @@
 
     "memorystream": ["memorystream@0.3.1", "", {}, "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="],
 
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micro-eth-signer": ["micro-eth-signer@0.14.0", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "micro-packed": "~0.7.2" } }, "sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw=="],
@@ -752,6 +768,8 @@
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "mimic-response": ["mimic-response@4.0.0", "", {}, "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="],
 
@@ -791,15 +809,21 @@
 
     "normalize-url": ["normalize-url@8.0.1", "", {}, "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w=="],
 
+    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
     "number-to-bn": ["number-to-bn@1.7.0", "", { "dependencies": { "bn.js": "4.11.6", "strip-hex-prefix": "1.0.0" } }, "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.3", "", {}, "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="],
 
+    "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
     "obliterator": ["obliterator@2.0.4", "", {}, "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "optionator": ["optionator@0.8.3", "", { "dependencies": { "deep-is": "~0.1.3", "fast-levenshtein": "~2.0.6", "levn": "~0.3.0", "prelude-ls": "~1.1.2", "type-check": "~0.3.2", "word-wrap": "~1.2.3" } }, "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA=="],
 
@@ -955,7 +979,7 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -992,6 +1016,8 @@
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "strip-hex-prefix": ["strip-hex-prefix@1.0.0", "", { "dependencies": { "is-hex-prefixed": "1.0.0" } }, "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A=="],
 
@@ -1067,7 +1093,7 @@
 
     "web3-utils": ["web3-utils@1.10.4", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "bn.js": "^5.2.1", "ethereum-bloom-filters": "^1.0.6", "ethereum-cryptography": "^2.1.2", "ethjs-unit": "0.1.6", "number-to-bn": "1.7.0", "randombytes": "^2.1.0", "utf8": "3.0.0" } }, "sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A=="],
 
-    "which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": "bin/which" }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
+    "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "widest-line": ["widest-line@3.1.0", "", { "dependencies": { "string-width": "^4.0.0" } }, "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg=="],
 
@@ -1173,15 +1199,23 @@
 
     "ethereumjs-util/ethereum-cryptography": ["ethereum-cryptography@0.1.3", "", { "dependencies": { "@types/pbkdf2": "^3.0.0", "@types/secp256k1": "^4.0.1", "blakejs": "^1.1.0", "browserify-aes": "^1.2.0", "bs58check": "^2.1.2", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "hash.js": "^1.1.7", "keccak": "^3.0.0", "pbkdf2": "^3.0.17", "randombytes": "^2.1.0", "safe-buffer": "^5.1.2", "scrypt-js": "^3.0.0", "secp256k1": "^4.0.1", "setimmediate": "^1.0.5" } }, "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ=="],
 
+    "ethers/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+
+    "ethers/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
     "ethers/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "ethers/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
     "ethjs-unit/bn.js": ["bn.js@4.11.6", "", {}, "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="],
 
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "ghost-testrpc/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+
+    "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": "bin/which" }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "globby/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -1223,6 +1257,8 @@
 
     "sc-istanbul/supports-color": ["supports-color@3.2.3", "", { "dependencies": { "has-flag": "^1.0.0" } }, "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A=="],
 
+    "sc-istanbul/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": "bin/which" }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
+
     "secp256k1/node-addon-api": ["node-addon-api@5.1.0", "", {}, "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="],
 
     "shelljs/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -1230,6 +1266,8 @@
     "solc/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "solc/semver": ["semver@5.7.2", "", { "bin": "bin/semver" }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "solhint/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "solhint/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
 
@@ -1307,6 +1345,8 @@
 
     "concat-stream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "ghost-testrpc/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -1314,6 +1354,8 @@
     "ghost-testrpc/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "ghost-testrpc/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "global-prefix/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "globby/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -1328,6 +1370,8 @@
     "sc-istanbul/js-yaml/esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "sc-istanbul/supports-color/has-flag": ["has-flag@1.0.0", "", {}, "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="],
+
+    "sc-istanbul/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "shelljs/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 

--- a/integrations/evm-hardhat/hardhat.config.ts
+++ b/integrations/evm-hardhat/hardhat.config.ts
@@ -1,11 +1,11 @@
 import type { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
-import dotenv from 'dotenv';
+import dotenvx from '@dotenvx/dotenvx';
 
 // PriceFeed Tasks
 import './tasks';
 
-dotenv.config();
+dotenvx.config();
 
 const config: HardhatUserConfig = {
   solidity: '0.8.28',

--- a/integrations/evm-hardhat/package.json
+++ b/integrations/evm-hardhat/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.2",
+    "@dotenvx/dotenvx": "^1.49.1",
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
-    "dotenv": "^17.2.1",
     "hardhat": "^2.26.1",
     "prettier": "^3.6.2",
     "prettier-plugin-solidity": "^2.1.0",

--- a/integrations/evm-hardhat/tasks/utils.ts
+++ b/integrations/evm-hardhat/tasks/utils.ts
@@ -1,10 +1,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import dotenv from 'dotenv';
+import dotenvx from '@dotenvx/dotenvx';
 import type { Network } from 'hardhat/types';
 import { networkConfigs, type SedaConfig } from '../seda.config';
 
-dotenv.config();
+dotenvx.config();
 
 /**
  * Helper function to fetch the deployed contract address from the deployment file.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "make build",
     "deploy": "bun run build && bunx seda-sdk oracle-program upload ./target/wasm32-wasip1/release-wasm/oracle-program.wasm",
     "post-dr": "bun run ./scripts/post-dr.ts",
-    "test": "bun run build && bun test"
+    "test": "bun test tests/ src/ --ignore='integrations/evm-foundry/lib/**'"
   },
   "keywords": [
     "seda",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@seda-protocol/dev-tools": "^1.0.1",
-    "@types/bun": "^1.2.13",
-    "bignumber.js": "^9.3.0",
-    "binaryen": "^123.0.0",
+    "@seda-protocol/dev-tools": "^1.0.3",
+    "@types/bun": "^1.2.22",
+    "bignumber.js": "^9.3.1",
+    "binaryen": "^124.0.0",
     "wabt": "^1.0.37"
   },
   "dependencies": {
-    "@seda-protocol/vm": "^1.0.14"
+    "@seda-protocol/vm": "^1.1.0"
   }
 }

--- a/src/tally_phase.rs
+++ b/src/tally_phase.rs
@@ -53,7 +53,7 @@ fn median(mut nums: Vec<u128>) -> u128 {
     nums.sort();
     let middle = nums.len() / 2;
 
-    if nums.len() % 2 == 0 {
+    if nums.len().is_multiple_of(2) {
         return (nums[middle - 1] + nums[middle]) / 2;
     }
 


### PR DESCRIPTION
## Motivation

This PR adds Foundry as an EVM integration option to the SEDA request starter kit and consolidates/improves the documentation. The starter kit previously only supported Hardhat for EVM development, limiting developer choice and missing out on Foundry's powerful testing and deployment capabilities.

## Explanation of Changes

- Added Foundry integration (`integrations/evm-foundry/`)
- Consolidated and improved READMEs
- Added GitHub Actions workflow

## Testing

**Foundry integration testing:**
```bash
# In integrations/evm-foundry/
forge install
forge build
forge test
forge script script/Deploy.s.sol:Deploy --rpc-url baseSepolia --broadcast
```

## Related PRs and Issues

Closes #31 