### PR TITLE
feat: Add dry-run/preflight checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build
 
 # Added by cargo
 /target
+
+*_*.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,3 @@ build
 
 # Added by cargo
 /target
-
-*_*.md

--- a/integrations/evm-hardhat/README.md
+++ b/integrations/evm-hardhat/README.md
@@ -81,15 +81,40 @@ bunx hardhat verify --network <NETWORK> <CONTRACT_ADDRESS> <CONSTRUCTOR_ARG_1> <
 
 ### 4. Interact with Your Contract
 
-**Create a Data Request:**
+#### Basic Workflow
+
+**1. Validate Request (Optional):**
 ```sh
-bunx hardhat pricefeed transmit --network baseSepolia
+bunx hardhat pricefeed dryrun --network baseSepolia --token evaa-protocol
 ```
 
-**Fetch the Latest Result:**
+**2. Submit Request:**
+```sh
+# Simple mode (zero fees)
+bunx hardhat pricefeed transmit --network baseSepolia --token evaa-protocol
+
+# Advanced mode (with custom fees)
+bunx hardhat pricefeed transmit --network baseSepolia --token bitcoin \
+  --request-fee 0.0001 --result-fee 0.0001 --batch-fee 0.0001
+```
+
+**3. Check Status:**
+```sh
+bunx hardhat pricefeed status --network baseSepolia
+```
+
+**4. Fetch Result:**
 ```sh
 bunx hardhat pricefeed latest --network baseSepolia
 ```
+
+#### Available Commands
+
+- `dryrun` - Validate request before submission (no gas cost)
+- `transmit` - Submit a data request (simple or advanced mode)
+- `status` - Check if result is ready (non-reverting)
+- `latest` - Get the price result (reverts if not ready)
+- `fullresult` - View complete result details for debugging
 
 ## Project Structure
 
@@ -116,8 +141,11 @@ The PriceFeed contract is a **destination contract** that:
 
 1. **Deploy Oracle Program** → Get `ORACLE_PROGRAM_ID`
 2. **Deploy PriceFeed Contract** → Uses the `ORACLE_PROGRAM_ID`
-3. **Call `transmit()`** → Creates a data request on SEDA network
-4. **Call `latestAnswer()`** → Retrieves the processed result
+3. **Call `dryrun()`** → Validate request parameters (optional)
+4. **Call `transmit()`** → Creates a data request on SEDA network
+5. **Call `status()`** → Check if result is ready
+6. **Call `latestAnswer()`** → Retrieves the processed result
+7. **Call `fullResult()`** → Retrieves the processed results and presents it in full 
 
 ## Testing
 

--- a/integrations/evm-hardhat/README.md
+++ b/integrations/evm-hardhat/README.md
@@ -70,6 +70,15 @@ By default, the deployment uses environment variables defined in your `.env` fil
 > [!NOTE]
 > The project includes a `seda.config.ts` file that contains SEDA-specific configurations including pre-configured core addresses for supported networks. You can modify this file to add support for additional networks or customize existing configurations.
 
+#### 3.1. Verify the deployed PriceFeed contract
+
+Note Mario: with the `--verify` on the initial deployment every single one failed to verify. But when I did verification in an isolated manner it succeeded. To discuss further.
+
+```sh
+bunx hardhat verify --network <NETWORK> <CONTRACT_ADDRESS> <CONSTRUCTOR_ARG_1> <CONSTRUCTOR_ARG_2>
+```
+
+
 ### 4. Interact with Your Contract
 
 **Create a Data Request:**

--- a/integrations/evm-hardhat/contracts/Defaults.sol
+++ b/integrations/evm-hardhat/contracts/Defaults.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {SedaDataTypes} from "@seda-protocol/evm/contracts/libraries/SedaDataTypes.sol";
+
+/**
+ * @title SedaDefaults
+ * @author Open Oracle Association
+ * @notice Provides sensible default configurations for SEDA Oracle requests
+ * @dev Inherit from this contract to use standardized request parameters
+ */
+abstract contract SedaDefaults {
+    /// @notice ID of the Oracle Program on the SEDA network
+    bytes32 public immutable ORACLE_PROGRAM_ID;
+
+    /**
+     * @notice Initialize with the Oracle Program ID
+     * @param _oracleProgramId The ID of your deployed Oracle Program
+     */
+    constructor(bytes32 _oracleProgramId) {
+        ORACLE_PROGRAM_ID = _oracleProgramId;
+    }
+
+    /**
+     * @notice Builds a RequestInputs struct with sensible defaults
+     * @param execInputs The input data for the Oracle Program (e.g., "evaa-protocol")
+     * @return inputs The configured RequestInputs struct
+     * @dev Override this function if you need different gas limits or replication factors
+     */
+    function buildRequestInputs(bytes memory execInputs) internal view virtual returns (SedaDataTypes.RequestInputs memory) {
+        return SedaDataTypes.RequestInputs({
+            execProgramId: ORACLE_PROGRAM_ID,
+            tallyProgramId: ORACLE_PROGRAM_ID,
+            gasPrice: 2000,                    // SEDA tokens per gas unit
+            execGasLimit: 50_000_000_000_000,  // Execution gas limit
+            tallyGasLimit: 20_000_000_000_000, // Tally gas limit  
+            replicationFactor: 1,               // Number of required executors
+            execInputs: execInputs,
+            tallyInputs: hex"00",               // No tally inputs needed
+            consensusFilter: hex"00",           // No consensus filter
+            memo: abi.encodePacked(block.number) // Block number as memo
+        });
+    }
+}

--- a/integrations/evm-hardhat/contracts/Defaults.sol
+++ b/integrations/evm-hardhat/contracts/Defaults.sol
@@ -13,6 +13,25 @@ abstract contract SedaDefaults {
     /// @notice ID of the Oracle Program on the SEDA network
     bytes32 public immutable ORACLE_PROGRAM_ID;
 
+    /// @notice Default fees for testnet usage (0 fees for testing)
+    uint256 public constant DEFAULT_REQUEST_FEE = 0;
+    uint256 public constant DEFAULT_RESULT_FEE = 0;
+    uint256 public constant DEFAULT_BATCH_FEE = 0;
+
+    /// @notice Default gas limits (safe values for most use cases)
+    uint64 public constant DEFAULT_EXEC_GAS_LIMIT = 50_000_000_000_000;
+    uint64 public constant DEFAULT_TALLY_GAS_LIMIT = 20_000_000_000_000;
+
+    /// @notice Default gas price in SEDA tokens per gas unit
+    uint128 public constant DEFAULT_GAS_PRICE = 2000;
+
+    /// @notice Default replication factor (minimum is 1)
+    uint16 public constant DEFAULT_REPLICATION_FACTOR = 1;
+
+    /// @notice Custom errors
+    error InsufficientFees(uint256 provided, uint256 required);
+    error InvalidToken(string token, string reason);
+
     /**
      * @notice Initialize with the Oracle Program ID
      * @param _oracleProgramId The ID of your deployed Oracle Program
@@ -31,14 +50,94 @@ abstract contract SedaDefaults {
         return SedaDataTypes.RequestInputs({
             execProgramId: ORACLE_PROGRAM_ID,
             tallyProgramId: ORACLE_PROGRAM_ID,
-            gasPrice: 2000,                    // SEDA tokens per gas unit
-            execGasLimit: 50_000_000_000_000,  // Execution gas limit
-            tallyGasLimit: 20_000_000_000_000, // Tally gas limit  
-            replicationFactor: 1,               // Number of required executors
+            gasPrice: DEFAULT_GAS_PRICE,
+            execGasLimit: DEFAULT_EXEC_GAS_LIMIT,
+            tallyGasLimit: DEFAULT_TALLY_GAS_LIMIT,
+            replicationFactor: DEFAULT_REPLICATION_FACTOR,
             execInputs: execInputs,
-            tallyInputs: hex"00",               // No tally inputs needed
-            consensusFilter: hex"00",           // No consensus filter
-            memo: abi.encodePacked(block.number) // Block number as memo
+            tallyInputs: hex"00",
+            consensusFilter: hex"00",
+            memo: abi.encodePacked(block.number)
         });
+    }
+
+    // TODO: Should we leave a more complex example with two oracles and consensus filter?
+
+    /**
+     * @notice Validates request inputs before submission
+     * @param execInputs The input data to validate
+     * @return isValid Whether the request inputs are valid
+     * @return reason Human-readable error reason if invalid
+     */
+    function validateRequest(bytes memory execInputs) public view virtual returns (bool isValid, string memory reason) {
+        if (execInputs.length == 0) {
+            return (false, "execInputs cannot be empty");
+        }
+        if (ORACLE_PROGRAM_ID == bytes32(0)) {
+            return (false, "Oracle Program ID not set");
+        }
+        return (true, "");
+    }
+
+    /**
+     * @notice Calculates the total required fee for a request
+     * @param requestFee Fee for request submission
+     * @param resultFee Fee for result submission
+     * @param batchFee Fee for batch processing
+     * @return total The sum of all fees
+     */
+    function calculateRequiredFee(
+        uint256 requestFee,
+        uint256 resultFee,
+        uint256 batchFee
+    ) public pure returns (uint256 total) {
+        return requestFee + resultFee + batchFee;
+    }
+
+    /**
+     * @notice Convert raw price (with 6 decimals) to human-readable string
+     * @param rawPrice The raw price value (e.g., 11340000)
+     * @return Human-readable price string (e.g., "11.34 USD")
+     */
+    function formatPrice(uint128 rawPrice) public pure returns (string memory) {
+        uint256 dollars = rawPrice / 1_000_000;
+        uint256 cents = (rawPrice % 1_000_000) / 10_000;
+        
+        // Format cents to always show 2 digits
+        string memory centsStr = uint2str(cents);
+        if (cents < 10) {
+            centsStr = string(abi.encodePacked("0", centsStr));
+        }
+        
+        return string(abi.encodePacked(uint2str(dollars), ".", centsStr, " USD"));
+    }
+
+    /**
+     * @notice Helper function to convert uint to string
+     * @param _i The uint to convert
+     * @return str The string representation
+     */
+    function uint2str(uint256 _i) internal pure returns (string memory str) {
+        if (_i == 0) {
+            return "0";
+        }
+        
+        uint256 j = _i;
+        uint256 length;
+        while (j != 0) {
+            length++;
+            j /= 10;
+        }
+        
+        bytes memory bstr = new bytes(length);
+        uint256 k = length;
+        j = _i;
+        
+        while (j != 0) {
+            bstr[--k] = bytes1(uint8(48 + j % 10));
+            j /= 10;
+        }
+        
+        str = string(bstr);
     }
 }

--- a/integrations/evm-hardhat/contracts/Defaults.sol
+++ b/integrations/evm-hardhat/contracts/Defaults.sol
@@ -46,19 +46,22 @@ abstract contract SedaDefaults {
      * @return inputs The configured RequestInputs struct
      * @dev Override this function if you need different gas limits or replication factors
      */
-    function buildRequestInputs(bytes memory execInputs) internal view virtual returns (SedaDataTypes.RequestInputs memory) {
-        return SedaDataTypes.RequestInputs({
-            execProgramId: ORACLE_PROGRAM_ID,
-            tallyProgramId: ORACLE_PROGRAM_ID,
-            gasPrice: DEFAULT_GAS_PRICE,
-            execGasLimit: DEFAULT_EXEC_GAS_LIMIT,
-            tallyGasLimit: DEFAULT_TALLY_GAS_LIMIT,
-            replicationFactor: DEFAULT_REPLICATION_FACTOR,
-            execInputs: execInputs,
-            tallyInputs: hex"00",
-            consensusFilter: hex"00",
-            memo: abi.encodePacked(block.number)
-        });
+    function buildRequestInputs(
+        bytes memory execInputs
+    ) internal view virtual returns (SedaDataTypes.RequestInputs memory) {
+        return
+            SedaDataTypes.RequestInputs({
+                execProgramId: ORACLE_PROGRAM_ID,
+                tallyProgramId: ORACLE_PROGRAM_ID,
+                gasPrice: DEFAULT_GAS_PRICE,
+                execGasLimit: DEFAULT_EXEC_GAS_LIMIT,
+                tallyGasLimit: DEFAULT_TALLY_GAS_LIMIT,
+                replicationFactor: DEFAULT_REPLICATION_FACTOR,
+                execInputs: execInputs,
+                tallyInputs: hex"00",
+                consensusFilter: hex"00",
+                memo: abi.encodePacked(block.number)
+            });
     }
 
     // TODO: Should we leave a more complex example with two oracles and consensus filter?
@@ -102,13 +105,13 @@ abstract contract SedaDefaults {
     function formatPrice(uint128 rawPrice) public pure returns (string memory) {
         uint256 dollars = rawPrice / 1_000_000;
         uint256 cents = (rawPrice % 1_000_000) / 10_000;
-        
+
         // Format cents to always show 2 digits
         string memory centsStr = uint2str(cents);
         if (cents < 10) {
             centsStr = string(abi.encodePacked("0", centsStr));
         }
-        
+
         return string(abi.encodePacked(uint2str(dollars), ".", centsStr, " USD"));
     }
 
@@ -121,23 +124,23 @@ abstract contract SedaDefaults {
         if (_i == 0) {
             return "0";
         }
-        
+
         uint256 j = _i;
         uint256 length;
         while (j != 0) {
             length++;
             j /= 10;
         }
-        
+
         bytes memory bstr = new bytes(length);
         uint256 k = length;
         j = _i;
-        
+
         while (j != 0) {
-            bstr[--k] = bytes1(uint8(48 + j % 10));
+            bstr[--k] = bytes1(uint8(48 + (j % 10)));
             j /= 10;
         }
-        
+
         str = string(bstr);
     }
 }

--- a/integrations/evm-hardhat/contracts/PriceFeed.sol
+++ b/integrations/evm-hardhat/contracts/PriceFeed.sol
@@ -39,7 +39,7 @@ contract PriceFeed {
     }
 
     /**
-     * @notice Creates a new ETH-USDC price request on the SEDA network
+     * @notice Creates a new EVAA Protocol price request on the SEDA network
      * @dev Demonstrates how to structure and send a request to SEDA
      * @param requestFee The fee for the request
      * @param resultFee The fee for the result
@@ -54,7 +54,7 @@ contract PriceFeed {
             50000000000000, // execGasLimit (within uint64 range)
             20000000000000, // tallyGasLimit (within uint64 range)
             1, // replicationFactor (number of required DR executors)
-            bytes("eth-usdc"), // execInputs (Inputs for Execution WASM)
+            bytes("evaa-protocol"), // execInputs (Inputs for Execution WASM)
             hex"00", // tallyInputs
             hex"00", // consensusFilter (set to `None`)
             abi.encodePacked(block.number) // memo (Additional public info)

--- a/integrations/evm-hardhat/contracts/PriceFeed.sol
+++ b/integrations/evm-hardhat/contracts/PriceFeed.sol
@@ -46,64 +46,54 @@ contract PriceFeed is SedaDefaults {
      * @return warnings Array of warning messages
      * @dev Use this to debug why transmit might fail before spending gas
      */
-    function dryRun(string calldata token) 
-        external 
-        view 
-        returns (
-            bool canSubmit,
-            uint256 estimatedCost,
-            string[] memory warnings
-        ) 
-    {
+    function dryRun(
+        string calldata token
+    ) external view returns (bool canSubmit, uint256 estimatedCost, string[] memory warnings) {
         warnings = new string[](5);
         uint256 warningCount = 0;
-        
+
         // Validate token input
         (bool valid, string memory reason) = validateRequest(bytes(token));
         if (!valid) {
             warnings[warningCount++] = reason;
             canSubmit = false;
-            
+
             // Resize warnings array
             assembly {
                 mstore(warnings, warningCount)
             }
             return (canSubmit, 0, warnings);
         }
-        
+
         // Check Oracle Program ID
         if (ORACLE_PROGRAM_ID == bytes32(0)) {
             warnings[warningCount++] = "Oracle Program ID not configured";
             canSubmit = false;
-            
+
             assembly {
                 mstore(warnings, warningCount)
             }
             return (canSubmit, 0, warnings);
         }
-        
+
         // Estimate cost (gas + fees)
         uint256 gasEstimate = 300000; // Typical gas for transmit
         uint256 gasPrice = tx.gasprice > 0 ? tx.gasprice : 1 gwei;
-        uint256 feeEstimate = calculateRequiredFee(
-            DEFAULT_REQUEST_FEE,
-            DEFAULT_RESULT_FEE,
-            DEFAULT_BATCH_FEE
-        );
+        uint256 feeEstimate = calculateRequiredFee(DEFAULT_REQUEST_FEE, DEFAULT_RESULT_FEE, DEFAULT_BATCH_FEE);
         estimatedCost = (gasEstimate * gasPrice) + feeEstimate;
-        
+
         // Check balance (if msg.sender is not address(0))
         if (msg.sender != address(0) && msg.sender.balance < estimatedCost) {
             warnings[warningCount++] = "Insufficient balance for transaction";
         }
-        
+
         // Check if token string is too long
         if (bytes(token).length > 256) {
             warnings[warningCount++] = "Token ID too long (max 256 chars)";
         }
-        
+
         canSubmit = (warningCount == 0);
-        
+
         // Resize warnings array
         assembly {
             mstore(warnings, warningCount)
@@ -139,7 +129,7 @@ contract PriceFeed is SedaDefaults {
         if (msg.value < requiredFee) {
             revert InsufficientFees(msg.value, requiredFee);
         }
-        
+
         return _transmit(token, requestFee, resultFee, batchFee);
     }
 
@@ -182,7 +172,7 @@ contract PriceFeed is SedaDefaults {
         if (requestId == bytes32(0)) {
             return (false, false);
         }
-        
+
         try SEDA_CORE.getResult(requestId) returns (SedaDataTypes.Result memory result) {
             return (true, result.consensus && result.exitCode == 0);
         } catch {

--- a/integrations/evm-hardhat/contracts/PriceFeed.sol
+++ b/integrations/evm-hardhat/contracts/PriceFeed.sol
@@ -23,6 +23,9 @@ contract PriceFeed is SedaDefaults {
     /// @notice ID of the most recent request
     bytes32 public requestId;
 
+    /// @notice Emitted when a new price request is submitted
+    event PriceRequested(bytes32 indexed requestId, string token, uint256 timestamp);
+
     /// @notice Thrown when trying to fetch results before any request is transmitted
     error RequestNotTransmitted();
 
@@ -36,26 +39,161 @@ contract PriceFeed is SedaDefaults {
     }
 
     /**
-     * @notice Creates a new EVAA Protocol price request on the SEDA network
-     * @dev Demonstrates how to structure and send a request to SEDA
-     * @param requestFee The fee for the request
-     * @param resultFee The fee for the result
-     * @param batchFee The fee for the batch
+     * @notice DRY-RUN: Simulate transmit without executing
+     * @param token Token ID to request (e.g., "bitcoin", "ethereum", "evaa-protocol")
+     * @return canSubmit Whether the request can be submitted
+     * @return estimatedCost Total ETH cost (gas estimate + fees)
+     * @return warnings Array of warning messages
+     * @dev Use this to debug why transmit might fail before spending gas
+     */
+    function dryRun(string calldata token) 
+        external 
+        view 
+        returns (
+            bool canSubmit,
+            uint256 estimatedCost,
+            string[] memory warnings
+        ) 
+    {
+        warnings = new string[](5);
+        uint256 warningCount = 0;
+        
+        // Validate token input
+        (bool valid, string memory reason) = validateRequest(bytes(token));
+        if (!valid) {
+            warnings[warningCount++] = reason;
+            canSubmit = false;
+            
+            // Resize warnings array
+            assembly {
+                mstore(warnings, warningCount)
+            }
+            return (canSubmit, 0, warnings);
+        }
+        
+        // Check Oracle Program ID
+        if (ORACLE_PROGRAM_ID == bytes32(0)) {
+            warnings[warningCount++] = "Oracle Program ID not configured";
+            canSubmit = false;
+            
+            assembly {
+                mstore(warnings, warningCount)
+            }
+            return (canSubmit, 0, warnings);
+        }
+        
+        // Estimate cost (gas + fees)
+        uint256 gasEstimate = 300000; // Typical gas for transmit
+        uint256 gasPrice = tx.gasprice > 0 ? tx.gasprice : 1 gwei;
+        uint256 feeEstimate = calculateRequiredFee(
+            DEFAULT_REQUEST_FEE,
+            DEFAULT_RESULT_FEE,
+            DEFAULT_BATCH_FEE
+        );
+        estimatedCost = (gasEstimate * gasPrice) + feeEstimate;
+        
+        // Check balance (if msg.sender is not address(0))
+        if (msg.sender != address(0) && msg.sender.balance < estimatedCost) {
+            warnings[warningCount++] = "Insufficient balance for transaction";
+        }
+        
+        // Check if token string is too long
+        if (bytes(token).length > 256) {
+            warnings[warningCount++] = "Token ID too long (max 256 chars)";
+        }
+        
+        canSubmit = (warningCount == 0);
+        
+        // Resize warnings array
+        assembly {
+            mstore(warnings, warningCount)
+        }
+    }
+
+    /**
+     * @notice Simple transmit with custom token and zero fees
+     * @param token Token ID to request (e.g., "bitcoin", "ethereum", "evaa-protocol")
+     * @return The ID of the created request
+     * @dev Perfect for testing - uses default zero fees
+     */
+    function transmit(string calldata token) external returns (bytes32) {
+        return _transmit(token, DEFAULT_REQUEST_FEE, DEFAULT_RESULT_FEE, DEFAULT_BATCH_FEE);
+    }
+
+    /**
+     * @notice Advanced transmit with full control over fees
+     * @param token Token ID to request
+     * @param requestFee Fee for request submission
+     * @param resultFee Fee for result submission
+     * @param batchFee Fee for batch processing
+     * @return The ID of the created request
+     * @dev For production use with custom fee structure
+     */
+    function transmit(
+        string calldata token,
+        uint256 requestFee,
+        uint256 resultFee,
+        uint256 batchFee
+    ) external payable returns (bytes32) {
+        uint256 requiredFee = calculateRequiredFee(requestFee, resultFee, batchFee);
+        if (msg.value < requiredFee) {
+            revert InsufficientFees(msg.value, requiredFee);
+        }
+        
+        return _transmit(token, requestFee, resultFee, batchFee);
+    }
+
+    /**
+     * @notice Internal transmit logic
+     * @param token Token ID to request
+     * @param requestFee Fee for request submission
+     * @param resultFee Fee for result submission
+     * @param batchFee Fee for batch processing
      * @return The ID of the created request
      */
-    function transmit(uint256 requestFee, uint256 resultFee, uint256 batchFee) external payable returns (bytes32) {
-        string memory execInput = "evaa-protocol";
-        SedaDataTypes.RequestInputs memory inputs = buildRequestInputs(bytes(execInput));
+    function _transmit(
+        string memory token,
+        uint256 requestFee,
+        uint256 resultFee,
+        uint256 batchFee
+    ) internal returns (bytes32) {
+        // Validate before submitting
+        (bool valid, string memory reason) = validateRequest(bytes(token));
+        if (!valid) {
+            revert InvalidToken(token, reason);
+        }
 
-        // Pass the msg.value as fees to the SEDA core
+        // Build and submit request
+        SedaDataTypes.RequestInputs memory inputs = buildRequestInputs(bytes(token));
         requestId = SEDA_CORE.postRequest{value: msg.value}(inputs, requestFee, resultFee, batchFee);
+
+        emit PriceRequested(requestId, token, block.timestamp);
+
         return requestId;
     }
 
     /**
+     * @notice Check if result is ready without reverting
+     * @return ready Whether result is available
+     * @return consensusReached Whether executors agreed on the result
+     * @dev Unlike latestAnswer(), this won't revert if no result exists
+     */
+    function isResultReady() public view returns (bool ready, bool consensusReached) {
+        if (requestId == bytes32(0)) {
+            return (false, false);
+        }
+        
+        try SEDA_CORE.getResult(requestId) returns (SedaDataTypes.Result memory result) {
+            return (true, result.consensus && result.exitCode == 0);
+        } catch {
+            return (false, false);
+        }
+    }
+
+    /**
      * @notice Retrieves the result of the latest request
-     * @dev Shows how to fetch and interpret SEDA request results
      * @return The price as uint128, or 0 if no consensus was reached
+     * @dev Reverts if no request has been submitted
      */
     function latestAnswer() public view returns (uint128) {
         if (requestId == bytes32(0)) revert RequestNotTransmitted();
@@ -67,5 +205,15 @@ contract PriceFeed is SedaDefaults {
         }
 
         return 0;
+    }
+
+    /**
+     * @notice Get full result details for debugging
+     * @return result The complete Result struct from SEDA
+     * @dev Shows ALL fields including gas used, timestamps, consensus, exit code, etc.
+     */
+    function getFullResult() external view returns (SedaDataTypes.Result memory result) {
+        if (requestId == bytes32(0)) revert RequestNotTransmitted();
+        return SEDA_CORE.getResult(requestId);
     }
 }

--- a/integrations/evm-hardhat/contracts/PriceFeed.sol
+++ b/integrations/evm-hardhat/contracts/PriceFeed.sol
@@ -8,6 +8,7 @@ pragma solidity 0.8.28;
 
 import {ISedaCore} from "@seda-protocol/evm/contracts/interfaces/ISedaCore.sol";
 import {SedaDataTypes} from "@seda-protocol/evm/contracts/libraries/SedaDataTypes.sol";
+import {SedaDefaults} from "./Defaults.sol";
 
 /**
  * @title PriceFeed
@@ -15,12 +16,9 @@ import {SedaDataTypes} from "@seda-protocol/evm/contracts/libraries/SedaDataType
  * @notice An example showing how to create and interact with SEDA network requests.
  * @dev This contract demonstrates basic SEDA request creation and result fetching.
  */
-contract PriceFeed {
+contract PriceFeed is SedaDefaults {
     /// @notice Instance of the SedaCore contract
     ISedaCore public immutable SEDA_CORE;
-
-    /// @notice ID of the request WASM binary on the SEDA network
-    bytes32 public immutable ORACLE_PROGRAM_ID;
 
     /// @notice ID of the most recent request
     bytes32 public requestId;
@@ -33,9 +31,8 @@ contract PriceFeed {
      * @param _sedaCoreAddress Address of the SedaCore contract
      * @param _oracleProgramId ID of the WASM binary for handling requests
      */
-    constructor(address _sedaCoreAddress, bytes32 _oracleProgramId) {
+    constructor(address _sedaCoreAddress, bytes32 _oracleProgramId) SedaDefaults(_oracleProgramId) {
         SEDA_CORE = ISedaCore(_sedaCoreAddress);
-        ORACLE_PROGRAM_ID = _oracleProgramId;
     }
 
     /**
@@ -47,18 +44,8 @@ contract PriceFeed {
      * @return The ID of the created request
      */
     function transmit(uint256 requestFee, uint256 resultFee, uint256 batchFee) external payable returns (bytes32) {
-        SedaDataTypes.RequestInputs memory inputs = SedaDataTypes.RequestInputs(
-            ORACLE_PROGRAM_ID, // execProgramId (Execution WASM binary ID)
-            ORACLE_PROGRAM_ID, // tallyProgramId (same as execProgramId in this example)
-            2000, // gasPrice (SEDA tokens per gas unit)
-            50000000000000, // execGasLimit (within uint64 range)
-            20000000000000, // tallyGasLimit (within uint64 range)
-            1, // replicationFactor (number of required DR executors)
-            bytes("evaa-protocol"), // execInputs (Inputs for Execution WASM)
-            hex"00", // tallyInputs
-            hex"00", // consensusFilter (set to `None`)
-            abi.encodePacked(block.number) // memo (Additional public info)
-        );
+        string memory execInput = "evaa-protocol";
+        SedaDataTypes.RequestInputs memory inputs = buildRequestInputs(bytes(execInput));
 
         // Pass the msg.value as fees to the SEDA core
         requestId = SEDA_CORE.postRequest{value: msg.value}(inputs, requestFee, resultFee, batchFee);

--- a/integrations/evm-hardhat/hardhat.config.ts
+++ b/integrations/evm-hardhat/hardhat.config.ts
@@ -42,14 +42,14 @@ const config: HardhatUserConfig = {
     },
     customChains: [
       {
-        network: "baseSepolia",
+        network: 'baseSepolia',
         chainId: 84532,
         urls: {
-          apiURL: "https://api.etherscan.io/v2/api?chainid=84532", // TODO: How to provide dynamically.
-          browserURL: "https://sepolia.basescan.org"
-        }
-      }
-    ]
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=84532', // TODO: How to provide dynamically.
+          browserURL: 'https://sepolia.basescan.org',
+        },
+      },
+    ],
   },
 };
 

--- a/integrations/evm-hardhat/hardhat.config.ts
+++ b/integrations/evm-hardhat/hardhat.config.ts
@@ -37,7 +37,19 @@ const config: HardhatUserConfig = {
     },
   },
   etherscan: {
-    apiKey: process.env.BASE_SEPOLIA_ETHERSCAN_API_KEY || '',
+    apiKey: {
+      baseSepolia: process.env.BASE_SEPOLIA_ETHERSCAN_API_KEY || '',
+    },
+    customChains: [
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=84532", // TODO: How to provide dynamically.
+          browserURL: "https://sepolia.basescan.org"
+        }
+      }
+    ]
   },
 };
 

--- a/integrations/evm-hardhat/tasks/dryrun.ts
+++ b/integrations/evm-hardhat/tasks/dryrun.ts
@@ -3,9 +3,9 @@ import { getDeployedContract } from './utils';
 
 /**
  * Hardhat task to perform a dry-run simulation of transmit without executing
- * 
+ *
  * Validates request parameters and estimates costs before spending gas.
- * 
+ *
  * @param contract - Optional PriceFeed contract address
  * @param token - Token ID to test (default: "evaa-protocol")
  */
@@ -23,7 +23,7 @@ priceFeedScope
       const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
       const [canSubmit, estimatedCost, warnings] = await priceFeed.dryRun(token);
 
-      console.log('\n' + '='.repeat(63));
+      console.log(`\n${'='.repeat(63)}`);
       console.log('DRY-RUN VALIDATION');
       console.log('='.repeat(63));
       console.log(`\nToken:      ${token}`);
@@ -35,16 +35,17 @@ priceFeedScope
         warnings.forEach((warning, i) => console.log(`  ${i + 1}. ${warning}`));
       }
 
-      console.log('\n' + '='.repeat(63));
+      console.log(`\n${'='.repeat(63)}`);
       console.log(canSubmit ? 'Ready to proceed' : 'Resolve issues before transmitting');
-      console.log('='.repeat(63) + '\n');
+      console.log(`${'='.repeat(63)}\n`);
 
       if (canSubmit) {
         console.log(`Next: bunx hardhat pricefeed transmit --network ${hre.network.name} --token ${token}\n`);
       }
-    } catch (error: any) {
-      console.error('\nError:', error.message || error);
-      if (error.message?.includes('dryRun')) {
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('\nError:', errorMessage);
+      if (errorMessage.includes('dryRun')) {
         console.error('Contract does not support dryRun. Redeploy with latest version.\n');
       }
     }

--- a/integrations/evm-hardhat/tasks/dryrun.ts
+++ b/integrations/evm-hardhat/tasks/dryrun.ts
@@ -1,0 +1,51 @@
+import { priceFeedScope } from '.';
+import { getDeployedContract } from './utils';
+
+/**
+ * Hardhat task to perform a dry-run simulation of transmit without executing
+ * 
+ * Validates request parameters and estimates costs before spending gas.
+ * 
+ * @param contract - Optional PriceFeed contract address
+ * @param token - Token ID to test (default: "evaa-protocol")
+ */
+priceFeedScope
+  .task('dryrun', 'Simulate transmit without executing (pre-flight validation)')
+  .addOptionalParam('contract', 'The PriceFeed contract address')
+  .addOptionalParam('token', 'Token ID to test', 'evaa-protocol')
+  .setAction(async ({ contract, token }, hre) => {
+    try {
+      let priceFeedAddress = contract;
+      if (!priceFeedAddress) {
+        priceFeedAddress = getDeployedContract(hre.network, 'PriceFeed');
+      }
+
+      const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
+      const [canSubmit, estimatedCost, warnings] = await priceFeed.dryRun(token);
+
+      console.log('\n' + '='.repeat(63));
+      console.log('DRY-RUN VALIDATION');
+      console.log('='.repeat(63));
+      console.log(`\nToken:      ${token}`);
+      console.log(`Status:       ${canSubmit ? 'READY' : 'BLOCKED'}`);
+      console.log(`Est. Cost:    ${hre.ethers.formatEther(estimatedCost)} ETH`);
+
+      if (warnings.length > 0) {
+        console.log(`\nIssues Found:`);
+        warnings.forEach((warning, i) => console.log(`  ${i + 1}. ${warning}`));
+      }
+
+      console.log('\n' + '='.repeat(63));
+      console.log(canSubmit ? 'Ready to proceed' : 'Resolve issues before transmitting');
+      console.log('='.repeat(63) + '\n');
+
+      if (canSubmit) {
+        console.log(`Next: bunx hardhat pricefeed transmit --network ${hre.network.name} --token ${token}\n`);
+      }
+    } catch (error: any) {
+      console.error('\nError:', error.message || error);
+      if (error.message?.includes('dryRun')) {
+        console.error('Contract does not support dryRun. Redeploy with latest version.\n');
+      }
+    }
+  });

--- a/integrations/evm-hardhat/tasks/fullresult.ts
+++ b/integrations/evm-hardhat/tasks/fullresult.ts
@@ -3,10 +3,10 @@ import { getDeployedContract } from './utils';
 
 /**
  * Hardhat task to retrieve complete result details for debugging
- * 
+ *
  * Displays all fields from the SEDA Result struct including consensus,
  * exit code, gas usage, timestamps, and raw result data.
- * 
+ *
  * @param contract - Optional PriceFeed contract address
  */
 priceFeedScope
@@ -22,7 +22,7 @@ priceFeedScope
       const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
       const result = await priceFeed.getFullResult();
 
-      console.log('\n' + '='.repeat(63));
+      console.log(`\n${'='.repeat(63)}`);
       console.log('FULL RESULT DETAILS');
       console.log('='.repeat(63));
 
@@ -31,7 +31,7 @@ priceFeedScope
       console.log(`  Consensus:    ${result.consensus}`);
       console.log(`  Exit Code:    ${result.exitCode}`);
       console.log(`  Raw (hex):    ${hre.ethers.hexlify(result.result)}`);
-      
+
       // Parse price if available
       if (result.result.length >= 16) {
         const resultBytes = hre.ethers.hexlify(result.result);
@@ -60,10 +60,10 @@ priceFeedScope
       console.log(`  Payback:      ${hre.ethers.hexlify(result.paybackAddress)}`);
       console.log(`  Payload:      ${hre.ethers.hexlify(result.sedaPayload)}`);
 
-      console.log('\n' + '='.repeat(63));
+      console.log(`\n${'='.repeat(63)}`);
 
       // Status interpretation
-      if (result.consensus && result.exitCode === 0) {
+      if (result.consensus && result.exitCode === 0n) {
         console.log('Status: SUCCESS - Oracle executed and reached consensus');
       } else if (!result.consensus) {
         console.log('Status: NO CONSENSUS - Executors did not agree');
@@ -71,17 +71,15 @@ priceFeedScope
         console.log(`Status: ERROR - Exit code ${result.exitCode}`);
       }
 
-      console.log('='.repeat(63) + '\n');
+      console.log(`${'='.repeat(63)}\n`);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('\nError:', errorMessage);
 
-    } catch (error: any) {
-      console.error('\nError:', error.message || error);
-      
-      if (error.message?.includes('RequestNotTransmitted')) {
+      if (errorMessage.includes('RequestNotTransmitted')) {
         console.error('No request submitted. Use: bunx hardhat pricefeed transmit\n');
-      } else if (error.message?.includes('ResultNotFound')) {
+      } else if (errorMessage.includes('ResultNotFound')) {
         console.error('Result not available yet. Check: bunx hardhat pricefeed status\n');
       }
     }
   });
-
-

--- a/integrations/evm-hardhat/tasks/fullresult.ts
+++ b/integrations/evm-hardhat/tasks/fullresult.ts
@@ -1,0 +1,87 @@
+import { priceFeedScope } from '.';
+import { getDeployedContract } from './utils';
+
+/**
+ * Hardhat task to retrieve complete result details for debugging
+ * 
+ * Displays all fields from the SEDA Result struct including consensus,
+ * exit code, gas usage, timestamps, and raw result data.
+ * 
+ * @param contract - Optional PriceFeed contract address
+ */
+priceFeedScope
+  .task('fullresult', 'Get complete result details (debugging)')
+  .addOptionalParam('contract', 'The PriceFeed contract address')
+  .setAction(async ({ contract }, hre) => {
+    try {
+      let priceFeedAddress = contract;
+      if (!priceFeedAddress) {
+        priceFeedAddress = getDeployedContract(hre.network, 'PriceFeed');
+      }
+
+      const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
+      const result = await priceFeed.getFullResult();
+
+      console.log('\n' + '='.repeat(63));
+      console.log('FULL RESULT DETAILS');
+      console.log('='.repeat(63));
+
+      // Core result
+      console.log('\nRESULT:');
+      console.log(`  Consensus:    ${result.consensus}`);
+      console.log(`  Exit Code:    ${result.exitCode}`);
+      console.log(`  Raw (hex):    ${hre.ethers.hexlify(result.result)}`);
+      
+      // Parse price if available
+      if (result.result.length >= 16) {
+        const resultBytes = hre.ethers.hexlify(result.result);
+        const priceHex = resultBytes.slice(0, 34); // 0x + 32 hex chars (16 bytes)
+        const price = BigInt(priceHex);
+        const formatted = await priceFeed.formatPrice(price);
+        console.log(`  Price:        ${formatted}`);
+        console.log(`  Raw Value:    ${price.toString()}`);
+      }
+
+      // Execution details
+      console.log('\nEXECUTION:');
+      console.log(`  DR ID:        ${result.drId}`);
+      console.log(`  Gas Used:     ${result.gasUsed.toString()}`);
+      console.log(`  Version:      ${result.version}`);
+
+      // Blockchain data
+      console.log('\nBLOCKCHAIN:');
+      console.log(`  Height:       ${result.blockHeight.toString()}`);
+      console.log(`  Timestamp:    ${result.blockTimestamp.toString()}`);
+      const date = new Date(Number(result.blockTimestamp) * 1000);
+      console.log(`  Time:         ${date.toISOString()}`);
+
+      // Additional metadata
+      console.log('\nMETADATA:');
+      console.log(`  Payback:      ${hre.ethers.hexlify(result.paybackAddress)}`);
+      console.log(`  Payload:      ${hre.ethers.hexlify(result.sedaPayload)}`);
+
+      console.log('\n' + '='.repeat(63));
+
+      // Status interpretation
+      if (result.consensus && result.exitCode === 0) {
+        console.log('Status: SUCCESS - Oracle executed and reached consensus');
+      } else if (!result.consensus) {
+        console.log('Status: NO CONSENSUS - Executors did not agree');
+      } else {
+        console.log(`Status: ERROR - Exit code ${result.exitCode}`);
+      }
+
+      console.log('='.repeat(63) + '\n');
+
+    } catch (error: any) {
+      console.error('\nError:', error.message || error);
+      
+      if (error.message?.includes('RequestNotTransmitted')) {
+        console.error('No request submitted. Use: bunx hardhat pricefeed transmit\n');
+      } else if (error.message?.includes('ResultNotFound')) {
+        console.error('Result not available yet. Check: bunx hardhat pricefeed status\n');
+      }
+    }
+  });
+
+

--- a/integrations/evm-hardhat/tasks/index.ts
+++ b/integrations/evm-hardhat/tasks/index.ts
@@ -6,5 +6,8 @@ import { scope } from 'hardhat/config';
 export const priceFeedScope = scope('pricefeed', 'Interact with the PriceFeed contract');
 
 import './deploy';
+import './dryrun';
+import './fullresult';
 import './latest';
+import './status';
 import './transmit';

--- a/integrations/evm-hardhat/tasks/status.ts
+++ b/integrations/evm-hardhat/tasks/status.ts
@@ -1,0 +1,55 @@
+import { priceFeedScope } from '.';
+import { getDeployedContract } from './utils';
+
+/**
+ * Hardhat task to check if result is ready without reverting
+ * 
+ * Safe status check that never throws errors. Use this before calling latestAnswer().
+ * 
+ * @param contract - Optional PriceFeed contract address
+ */
+priceFeedScope
+  .task('status', 'Check result status (non-reverting)')
+  .addOptionalParam('contract', 'The PriceFeed contract address')
+  .setAction(async ({ contract }, hre) => {
+    try {
+      let priceFeedAddress = contract;
+      if (!priceFeedAddress) {
+        priceFeedAddress = getDeployedContract(hre.network, 'PriceFeed');
+      }
+
+      const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
+      const [ready, consensus] = await priceFeed.isResultReady();
+
+      console.log('\n' + '='.repeat(63));
+      console.log('REQUEST STATUS');
+      console.log('='.repeat(63));
+
+      if (ready && consensus) {
+        const price = await priceFeed.latestAnswer();
+        const formatted = await priceFeed.formatPrice(price);
+        
+        console.log(`\nStatus:       COMPLETED`);
+        console.log(`Consensus:    YES`);
+        console.log(`Price:        ${formatted}`);
+        console.log(`Raw Value:    ${price.toString()}`);
+        
+      } else if (ready && !consensus) {
+        console.log(`\nStatus:       COMPLETED`);
+        console.log(`Consensus:    NO`);
+        console.log(`\nExecutors did not reach consensus on the result.`);
+        
+      } else {
+        console.log(`\nStatus:       PENDING`);
+        console.log(`\nRequest is being processed by SEDA executors.`);
+        console.log(`Typical processing time: 30-60 seconds`);
+      }
+
+      console.log('\n' + '='.repeat(63) + '\n');
+
+    } catch (error: any) {
+      console.error('\nError:', error.message || error, '\n');
+    }
+  });
+
+

--- a/integrations/evm-hardhat/tasks/status.ts
+++ b/integrations/evm-hardhat/tasks/status.ts
@@ -3,9 +3,9 @@ import { getDeployedContract } from './utils';
 
 /**
  * Hardhat task to check if result is ready without reverting
- * 
+ *
  * Safe status check that never throws errors. Use this before calling latestAnswer().
- * 
+ *
  * @param contract - Optional PriceFeed contract address
  */
 priceFeedScope
@@ -21,35 +21,31 @@ priceFeedScope
       const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
       const [ready, consensus] = await priceFeed.isResultReady();
 
-      console.log('\n' + '='.repeat(63));
+      console.log(`\n${'='.repeat(63)}`);
       console.log('REQUEST STATUS');
       console.log('='.repeat(63));
 
       if (ready && consensus) {
         const price = await priceFeed.latestAnswer();
         const formatted = await priceFeed.formatPrice(price);
-        
+
         console.log(`\nStatus:       COMPLETED`);
         console.log(`Consensus:    YES`);
         console.log(`Price:        ${formatted}`);
         console.log(`Raw Value:    ${price.toString()}`);
-        
       } else if (ready && !consensus) {
         console.log(`\nStatus:       COMPLETED`);
         console.log(`Consensus:    NO`);
         console.log(`\nExecutors did not reach consensus on the result.`);
-        
       } else {
         console.log(`\nStatus:       PENDING`);
         console.log(`\nRequest is being processed by SEDA executors.`);
         console.log(`Typical processing time: 30-60 seconds`);
       }
 
-      console.log('\n' + '='.repeat(63) + '\n');
-
-    } catch (error: any) {
-      console.error('\nError:', error.message || error, '\n');
+      console.log(`\n${'='.repeat(63)}\n`);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('\nError:', errorMessage, '\n');
     }
   });
-
-

--- a/integrations/evm-hardhat/tasks/transmit.ts
+++ b/integrations/evm-hardhat/tasks/transmit.ts
@@ -1,73 +1,99 @@
 import { priceFeedScope } from '.';
 import { getDeployedContract } from './utils';
 
-// Default fees in ETH
-const DEFAULT_FEE = '0.0001';
-
 /**
- * Task: Calls the transmit function on the PriceFeed contract.
- * Optional parameters:
- * - contract: PriceFeed contract address
- * - requestFee: Fee for data request (in ETH)
- * - resultFee: Fee for result processing (in ETH)
- * - batchFee: Fee for batch operations (in ETH)
- *
- * If parameters are not provided, default values are used.
+ * Hardhat task to submit a price request to the SEDA network
+ * 
+ * Supports two modes:
+ * - Simple mode: transmit(token) with zero fees
+ * - Advanced mode: transmit(token, fees...) with custom fees
+ * 
+ * @param contract - Optional PriceFeed contract address
+ * @param token - Token ID to request (default: "evaa-protocol")
+ * @param requestFee - Optional request fee (triggers advanced mode)
+ * @param resultFee - Optional result fee (triggers advanced mode)
+ * @param batchFee - Optional batch fee (triggers advanced mode)
  */
 priceFeedScope
-  .task('transmit', 'Calls the transmit function on the PriceFeed contract')
+  .task('transmit', 'Submit a price request to SEDA network')
   .addOptionalParam('contract', 'The PriceFeed contract address')
-  .addOptionalParam('requestFee', 'Fee for data request (in ETH)', DEFAULT_FEE)
-  .addOptionalParam('resultFee', 'Fee for result processing (in ETH)', DEFAULT_FEE)
-  .addOptionalParam('batchFee', 'Fee for batch operations (in ETH)', DEFAULT_FEE)
-  .setAction(async ({ contract, requestFee, resultFee, batchFee }, hre) => {
+  .addOptionalParam('token', 'Token ID to request', 'evaa-protocol')
+  .addOptionalParam('requestFee', 'Request fee in ETH (enables advanced mode)')
+  .addOptionalParam('resultFee', 'Result fee in ETH (enables advanced mode)')
+  .addOptionalParam('batchFee', 'Batch fee in ETH (enables advanced mode)')
+  .setAction(async ({ contract, token, requestFee, resultFee, batchFee }, hre) => {
     try {
-      // Fetch the address from previous deployments if not provided
       let priceFeedAddress = contract;
       if (!priceFeedAddress) {
-        console.log('No contract address specified, fetching from previous deployments...');
         priceFeedAddress = getDeployedContract(hre.network, 'PriceFeed');
-        console.log('Contract found:', priceFeedAddress);
       }
 
-      // Parse the fee values
-      const parsedRequestFee = hre.ethers.parseEther(requestFee);
-      const parsedResultFee = hre.ethers.parseEther(resultFee);
-      const parsedBatchFee = hre.ethers.parseEther(batchFee);
-
-      // Calculate total value for the transaction
-      const totalValue = parsedRequestFee + parsedResultFee + parsedBatchFee;
-
-      // Get the PriceFeed contract instance
       const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
+      const useAdvancedMode = requestFee !== undefined || resultFee !== undefined || batchFee !== undefined;
 
-      // Call the transmit function
-      console.log(`\nCalling transmit() on PriceFeed at ${priceFeedAddress}...\n`);
-      console.log(`Fees (ETH):
-- Request Fee: ${requestFee}
-- Result Fee: ${resultFee}
-- Batch Fee: ${batchFee}
-- Total: ${hre.ethers.formatEther(totalValue)}\n`);
+      let receipt;
 
-      const tx = await priceFeed.transmit(parsedRequestFee, parsedResultFee, parsedBatchFee, { value: totalValue });
+      if (useAdvancedMode) {
+        const parsedRequestFee = hre.ethers.parseEther(requestFee || '0');
+        const parsedResultFee = hre.ethers.parseEther(resultFee || '0');
+        const parsedBatchFee = hre.ethers.parseEther(batchFee || '0');
+        const totalValue = parsedRequestFee + parsedResultFee + parsedBatchFee;
 
-      // Wait for the transaction
-      const receipt = await tx.wait();
+        console.log('\n' + '='.repeat(63));
+        console.log(`TRANSMIT [ADVANCED] - ${token}`);
+        console.log('='.repeat(63));
+        console.log(`Request Fee:  ${requestFee || '0'} ETH`);
+        console.log(`Result Fee:   ${resultFee || '0'} ETH`);
+        console.log(`Batch Fee:    ${batchFee || '0'} ETH`);
+        console.log(`Total:        ${hre.ethers.formatEther(totalValue)} ETH`);
+        console.log('='.repeat(63) + '\n');
+
+        const tx = await priceFeed['transmit(string,uint256,uint256,uint256)'](
+          token,
+          parsedRequestFee,
+          parsedResultFee,
+          parsedBatchFee,
+          { value: totalValue }
+        );
+
+        receipt = await tx.wait();
+      } else {
+        console.log('\n' + '='.repeat(63));
+        console.log(`TRANSMIT [SIMPLE] - ${token}`);
+        console.log('='.repeat(63));
+        console.log(`Fees: Zero`);
+        console.log('='.repeat(63) + '\n');
+
+        const tx = await priceFeed['transmit(string)'](token);
+        receipt = await tx.wait();
+      }
+
       if (!receipt) {
-        console.log('Transaction failed - no receipt received');
+        console.error('Transaction failed - no receipt received\n');
         return;
       }
-      console.log(`Request submitted successfully!`);
 
-      // Find request ID in event logs
-      const requestPostedLog = receipt.logs.find((log) => log.topics[0] === hre.ethers.id('RequestPosted(bytes32)'));
-      if (requestPostedLog) {
-        const requestId = requestPostedLog.topics[1];
+      console.log('Transaction confirmed\n');
+
+      // Extract request ID from events
+      const priceRequestedTopic = hre.ethers.id('PriceRequested(bytes32,string,uint256)');
+      const priceRequestedLog = receipt.logs.find((log: any) => log.topics[0] === priceRequestedTopic);
+      
+      if (priceRequestedLog) {
+        const requestId = priceRequestedLog.topics[1];
         console.log(`Request ID: ${requestId}`);
-      } else {
-        console.log('Transaction successful but could not extract request ID');
+        console.log(`Token:      ${token}\n`);
+        console.log(`Processing time: ~30-60 seconds`);
+        console.log(`Check status: bunx hardhat pricefeed status --network ${hre.network.name}\n`);
       }
-    } catch (error) {
-      console.error('An error occurred during the transmit function:', error);
+
+    } catch (error: any) {
+      console.error('\nError:', error.message || error);
+      
+      if (error.message?.includes('InsufficientFees')) {
+        console.error('Insufficient fees. Ensure msg.value >= sum of all fees\n');
+      } else if (error.message?.includes('InvalidToken')) {
+        console.error('Invalid token. Token ID cannot be empty\n');
+      }
     }
   });

--- a/integrations/evm-hardhat/tasks/transmit.ts
+++ b/integrations/evm-hardhat/tasks/transmit.ts
@@ -3,11 +3,11 @@ import { getDeployedContract } from './utils';
 
 /**
  * Hardhat task to submit a price request to the SEDA network
- * 
+ *
  * Supports two modes:
  * - Simple mode: transmit(token) with zero fees
  * - Advanced mode: transmit(token, fees...) with custom fees
- * 
+ *
  * @param contract - Optional PriceFeed contract address
  * @param token - Token ID to request (default: "evaa-protocol")
  * @param requestFee - Optional request fee (triggers advanced mode)
@@ -31,7 +31,7 @@ priceFeedScope
       const priceFeed = await hre.ethers.getContractAt('PriceFeed', priceFeedAddress);
       const useAdvancedMode = requestFee !== undefined || resultFee !== undefined || batchFee !== undefined;
 
-      let receipt;
+      let receipt: Awaited<ReturnType<typeof priceFeed.transmit.send>> | null = null;
 
       if (useAdvancedMode) {
         const parsedRequestFee = hre.ethers.parseEther(requestFee || '0');
@@ -39,30 +39,30 @@ priceFeedScope
         const parsedBatchFee = hre.ethers.parseEther(batchFee || '0');
         const totalValue = parsedRequestFee + parsedResultFee + parsedBatchFee;
 
-        console.log('\n' + '='.repeat(63));
+        console.log(`\n${'='.repeat(63)}`);
         console.log(`TRANSMIT [ADVANCED] - ${token}`);
         console.log('='.repeat(63));
         console.log(`Request Fee:  ${requestFee || '0'} ETH`);
         console.log(`Result Fee:   ${resultFee || '0'} ETH`);
         console.log(`Batch Fee:    ${batchFee || '0'} ETH`);
         console.log(`Total:        ${hre.ethers.formatEther(totalValue)} ETH`);
-        console.log('='.repeat(63) + '\n');
+        console.log(`${'='.repeat(63)}\n`);
 
         const tx = await priceFeed['transmit(string,uint256,uint256,uint256)'](
           token,
           parsedRequestFee,
           parsedResultFee,
           parsedBatchFee,
-          { value: totalValue }
+          { value: totalValue },
         );
 
         receipt = await tx.wait();
       } else {
-        console.log('\n' + '='.repeat(63));
+        console.log(`\n${'='.repeat(63)}`);
         console.log(`TRANSMIT [SIMPLE] - ${token}`);
         console.log('='.repeat(63));
         console.log(`Fees: Zero`);
-        console.log('='.repeat(63) + '\n');
+        console.log(`${'='.repeat(63)}\n`);
 
         const tx = await priceFeed['transmit(string)'](token);
         receipt = await tx.wait();
@@ -77,8 +77,8 @@ priceFeedScope
 
       // Extract request ID from events
       const priceRequestedTopic = hre.ethers.id('PriceRequested(bytes32,string,uint256)');
-      const priceRequestedLog = receipt.logs.find((log: any) => log.topics[0] === priceRequestedTopic);
-      
+      const priceRequestedLog = receipt.logs.find((log) => log.topics[0] === priceRequestedTopic);
+
       if (priceRequestedLog) {
         const requestId = priceRequestedLog.topics[1];
         console.log(`Request ID: ${requestId}`);
@@ -86,13 +86,13 @@ priceFeedScope
         console.log(`Processing time: ~30-60 seconds`);
         console.log(`Check status: bunx hardhat pricefeed status --network ${hre.network.name}\n`);
       }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('\nError:', errorMessage);
 
-    } catch (error: any) {
-      console.error('\nError:', error.message || error);
-      
-      if (error.message?.includes('InsufficientFees')) {
+      if (errorMessage.includes('InsufficientFees')) {
         console.error('Insufficient fees. Ensure msg.value >= sum of all fees\n');
-      } else if (error.message?.includes('InvalidToken')) {
+      } else if (errorMessage.includes('InvalidToken')) {
         console.error('Invalid token. Token ID cannot be empty\n');
       }
     }

--- a/integrations/evm-hardhat/test/PriceFeed.ts
+++ b/integrations/evm-hardhat/test/PriceFeed.ts
@@ -9,7 +9,6 @@ describe('PriceFeed Contract', () => {
     const [admin] = await ethers.getSigners();
 
     // A Data Request WASM binary ID (mock value - must be non-zero)
-    // TODO: Why was here ethers.ZeroHash;
     const oracleProgramId = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
     // Deploy MockSedaCore

--- a/integrations/evm-hardhat/test/PriceFeed.ts
+++ b/integrations/evm-hardhat/test/PriceFeed.ts
@@ -8,8 +8,9 @@ describe('PriceFeed Contract', () => {
   async function deployPriceFeedFixture() {
     const [admin] = await ethers.getSigners();
 
-    // A Data Request WASM binary ID (mock value)
-    const oracleProgramId = ethers.ZeroHash;
+    // A Data Request WASM binary ID (mock value - must be non-zero)
+    // TODO: Why was here ethers.ZeroHash;
+    const oracleProgramId = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
     // Deploy MockSedaCore
     const SedaCore = await ethers.getContractFactoryFromArtifact(MockSedaCore);
@@ -42,8 +43,8 @@ describe('PriceFeed Contract', () => {
   it('Should revert if data result is not found', async () => {
     const { priceFeed, core } = await loadFixture(deployPriceFeedFixture);
 
-    // Transmit the data request (but no result set)
-    await priceFeed.transmit(0, 0, 0);
+    // Transmit the data request using the simple mode (but no result set)
+    await priceFeed['transmit(string)']('evaa-protocol');
 
     // latestAnswer should revert due to no data result being set
     await expect(priceFeed.latestAnswer()).to.be.revertedWithCustomError(core, 'ResultNotFound');
@@ -56,8 +57,8 @@ describe('PriceFeed Contract', () => {
   it('Should return the correct latest answer if consensus is reached', async () => {
     const { priceFeed, core } = await loadFixture(deployPriceFeedFixture);
 
-    // Transmit a data request
-    await priceFeed.transmit(0, 0, 0);
+    // Transmit a data request using simple mode
+    await priceFeed['transmit(string)']('evaa-protocol');
     const dataRequestId = await priceFeed.requestId();
 
     // Set a data result with consensus in the contract
@@ -88,8 +89,8 @@ describe('PriceFeed Contract', () => {
   it('Should return latest answer (zero) if consensus is not reached', async () => {
     const { priceFeed, core } = await loadFixture(deployPriceFeedFixture);
 
-    // Transmit a data request
-    await priceFeed.transmit(0, 0, 0);
+    // Transmit a data request using simple mode
+    await priceFeed['transmit(string)']('evaa-protocol');
     const dataRequestId = await priceFeed.requestId();
 
     // Set a data result without consensus (false)
@@ -124,8 +125,8 @@ describe('PriceFeed Contract', () => {
     let dataRequestId = await priceFeed.requestId();
     expect(dataRequestId).to.be.equal(ethers.ZeroHash);
 
-    // Call the transmit function
-    await priceFeed.transmit(0, 0, 0);
+    // Call the transmit function using simple mode
+    await priceFeed['transmit(string)']('evaa-protocol');
 
     // Check that the data request ID is valid and stored correctly
     dataRequestId = await priceFeed.requestId();

--- a/scripts/post-dr.ts
+++ b/scripts/post-dr.ts
@@ -11,15 +11,23 @@ async function main() {
 
     console.log('Posting and waiting for a result, this may take a little while..');
 
+    // Input formats:
+    // - "binance:ETHUSDC" or "binance:BTCUSDT" -> Binance API
+    // - "evaa-protocol" or "bitcoin" or "ethereum" -> CoinGecko API (default)
+    
+    const selectedInput = "evaa-protocol";  // EVAA Protocol price from CoinGecko
+
     const dataRequestInput: PostDataRequestInput = {
         consensusOptions: {
             method: 'none'
         },
         execProgramId: process.env.ORACLE_PROGRAM_ID,
-        execInputs: Buffer.from('eth-usdc'),
+        execInputs: Buffer.from(selectedInput),
         tallyInputs: Buffer.from([]),
         memo: Buffer.from(new Date().toISOString()),
     };
+
+    console.log(`Requesting price for: ${selectedInput}`);
 
     const result = await postAndAwaitDataRequest(signer, dataRequestInput, {});
     const explorerLink = process.env.SEDA_EXPLORER_URL ? process.env.SEDA_EXPLORER_URL + `/data-requests/${result.drId}/${result.drBlockHeight}` : "Configure env.SEDA_EXPLORER_URL to generate a link to your DR";

--- a/src/execution_phase.rs
+++ b/src/execution_phase.rs
@@ -2,66 +2,117 @@ use anyhow::Result;
 use seda_sdk_rs::{elog, http_fetch, log, Process};
 use serde::{Deserialize, Serialize};
 
+// Binance API response structure
 #[derive(Serialize, Deserialize)]
-struct PriceFeedResponse {
+struct BinancePriceResponse {
     price: String,
+}
+
+// CoinGecko Simple Price API response structure
+// Example: {"evaa-protocol":{"usd":11.34}}
+#[derive(Serialize, Deserialize)]
+struct CoinGeckoSimplePrice {
+    usd: f64,
 }
 
 /**
  * Executes the data request phase within the SEDA network.
- * This phase is responsible for fetching non-deterministic data (e.g., price of an asset pair)
- * from an external source such as a price feed API. The input specifies the asset pair to fetch.
+ * 
+ * Supported input formats:
+ * - "binance:ETHUSDC" or "binance:BTCUSDT" - Fetches from Binance API (no separator needed)
+ * - Any other input - Fetches from CoinGecko Simple Price API (e.g., "evaa-protocol", "bitcoin")
+ * 
+ * Examples:
+ * - "binance:ETHUSDC" -> Binance
+ * - "evaa-protocol" -> CoinGecko
+ * - "bitcoin" -> CoinGecko
  */
 pub fn execution_phase() -> Result<()> {
-    // Retrieve the input parameters for the data request (DR).
-    // Expected to be in the format "symbolA-symbolB" (e.g., "BTC-USDT").
     let dr_inputs_raw = String::from_utf8(Process::get_inputs())?;
+    log!("Fetching price for: {}", dr_inputs_raw);
 
-    // Log the asset pair being fetched as part of the Execution Standard Out.
-    log!("Fetching price for pair: {}", dr_inputs_raw);
+    let price = if let Some(symbol) = dr_inputs_raw.strip_prefix("binance:") {
+        fetch_binance_price(symbol)?
+    } else {
+        fetch_coingecko_price(&dr_inputs_raw)?
+    };
 
-    // Split the input string into symbolA and symbolB.
-    // Example: "ETH-USDC" will be split into "ETH" and "USDC".
-    let dr_inputs: Vec<&str> = dr_inputs_raw.split("-").collect();
-    let symbol_a = dr_inputs.first().expect("format should be tokenA-tokenB");
-    let symbol_b = dr_inputs.get(1).expect("format should be tokenA-tokenB");
+    log!("Fetched price: {}", price);
 
+    // Convert to integer (multiply by 1e6 to maintain 6 decimal places precision)
+    let result = (price * 1000000f32) as u128;
+    log!("Reporting: {}", result);
+
+    Process::success(&result.to_le_bytes());
+    Ok(())
+}
+
+/**
+ * Fetches price from Binance API
+ * Input: Trading pair symbol without separator (e.g., "ETHUSDC", "BTCUSDT")
+ */
+fn fetch_binance_price(symbol: &str) -> Result<f32> {
     let response = http_fetch(
         format!(
-            "https://api.binance.com/api/v3/ticker/price?symbol={}{}",
-            symbol_a.to_uppercase(),
-            symbol_b.to_uppercase()
+            "https://api.binance.com/api/v3/ticker/price?symbol={}",
+            symbol.to_uppercase()
         ),
         None,
     );
 
-    // Check if the HTTP request was successfully fulfilled.
     if !response.is_ok() {
-        // Handle the case where the HTTP request failed or was rejected.
         elog!(
-            "HTTP Response was rejected: {} - {}",
+            "Binance API error: {} - {}",
             response.status,
             String::from_utf8(response.bytes)?
         );
-
-        // Report the failure to the SEDA network with an error code of 1.
-        Process::error("Error while fetching price feed".as_bytes());
-
-        return Ok(());
+        Process::error("Error fetching from Binance API".as_bytes());
+        return Err(anyhow::anyhow!("Binance API request failed"));
     }
 
-    // Parse the API response as defined earlier.
-    let data = serde_json::from_slice::<PriceFeedResponse>(&response.bytes)?;
+    let data = serde_json::from_slice::<BinancePriceResponse>(&response.bytes)?;
+    Ok(data.price.parse()?)
+}
 
-    // Convert to integer (and multiply by 1e6 to avoid losing precision).
-    let price: f32 = data.price.parse()?;
-    log!("Fetched price: {}", price);
+/**
+ * Fetches price from CoinGecko Simple Price API
+ * Input: Token ID as listed on CoinGecko (e.g., "evaa-protocol", "bitcoin", "ethereum")
+ * 
+ * Uses the simple/price endpoint which returns: {"token-id":{"usd":123.45}}
+ */
+fn fetch_coingecko_price(token_id: &str) -> Result<f32> {
+    log!("Fetching CoinGecko price for: {}", token_id);
 
-    let result = (price * 1000000f32) as u128;
-    log!("Reporting: {}", result);
+    let response = http_fetch(
+        format!(
+            "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
+            token_id.to_lowercase()
+        ),
+        None,
+    );
 
-    // Report the successful result back to the SEDA network.
-    Process::success(&result.to_le_bytes());
+    if !response.is_ok() {
+        elog!(
+            "CoinGecko API error: {} - {}",
+            response.status,
+            String::from_utf8(response.bytes.clone())?
+        );
+        Process::error("Error fetching from CoinGecko API".as_bytes());
+        return Err(anyhow::anyhow!("CoinGecko API request failed"));
+    }
 
-    Ok(())
+    // Parse response: {"token-id":{"usd":123.45}}
+    let response_json: serde_json::Value = serde_json::from_slice(&response.bytes)?;
+    
+    // Get the token object
+    let token_data = response_json.get(token_id)
+        .ok_or_else(|| {
+            elog!("Token '{}' not found in CoinGecko response", token_id);
+            anyhow::anyhow!("Token not found")
+        })?;
+    
+    // Get the USD price
+    let price_data: CoinGeckoSimplePrice = serde_json::from_value(token_data.clone())?;
+    
+    Ok(price_data.usd as f32)
 }

--- a/src/execution_phase.rs
+++ b/src/execution_phase.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use seda_sdk_rs::{elog, http_fetch, log, Process};
+use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 // Binance API response structure
 #[derive(Serialize, Deserialize)]
@@ -80,16 +81,42 @@ fn fetch_binance_price(symbol: &str) -> Result<f32> {
  * 
  * Uses the simple/price endpoint which returns: {"token-id":{"usd":123.45}}
  */
-fn fetch_coingecko_price(token_id: &str) -> Result<f32> {
+fn fetch_coingecko_price(token_input: &str) -> Result<f32> {
+    // Check if API key is provided (format: "token-id:api-key")
+    let (token_id, api_key_opt) = if let Some(colon_pos) = token_input.rfind(':') {
+        let token = &token_input[..colon_pos];
+        let key = &token_input[colon_pos + 1..];
+        (token, Some(key))
+    } else {
+        (token_input, None)
+    };
+    
     log!("Fetching CoinGecko price for: {}", token_id);
 
-    let response = http_fetch(
-        format!(
+    // Build URL and headers based on whether we have Pro API key
+    let (url, options) = if let Some(api_key) = api_key_opt {
+        log!("Using CoinGecko Pro API");
+        let url = format!(
+            "https://pro-api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
+            token_id.to_lowercase()
+        );
+        let mut headers = BTreeMap::new();
+        headers.insert("x-cg-pro-api-key".to_string(), api_key.to_string());
+        let options = HttpFetchOptions {
+            headers,
+            ..Default::default()
+        };
+        (url, Some(options))
+    } else {
+        log!("Using CoinGecko Free API");
+        let url = format!(
             "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
             token_id.to_lowercase()
-        ),
-        None,
-    );
+        );
+        (url, None)
+    };
+
+    let response = http_fetch(url, options);
 
     if !response.is_ok() {
         elog!(

--- a/src/execution_phase.rs
+++ b/src/execution_phase.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use seda_sdk_rs::{elog, http_fetch, log, Process, HttpFetchOptions};
+use seda_sdk_rs::{elog, http_fetch, log, HttpFetchOptions, Process};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -18,11 +18,11 @@ struct CoinGeckoSimplePrice {
 
 /**
  * Executes the data request phase within the SEDA network.
- * 
+ *
  * Supported input formats:
  * - "binance:ETHUSDC" or "binance:BTCUSDT" - Fetches from Binance API (no separator needed)
  * - Any other input - Fetches from CoinGecko Simple Price API (e.g., "evaa-protocol", "bitcoin")
- * 
+ *
  * Examples:
  * - "binance:ETHUSDC" -> Binance
  * - "evaa-protocol" -> CoinGecko
@@ -78,7 +78,7 @@ fn fetch_binance_price(symbol: &str) -> Result<f32> {
 /**
  * Fetches price from CoinGecko Simple Price API
  * Input: Token ID as listed on CoinGecko (e.g., "evaa-protocol", "bitcoin", "ethereum")
- * 
+ *
  * Uses the simple/price endpoint which returns: {"token-id":{"usd":123.45}}
  */
 fn fetch_coingecko_price(token_input: &str) -> Result<f32> {
@@ -90,7 +90,7 @@ fn fetch_coingecko_price(token_input: &str) -> Result<f32> {
     } else {
         (token_input, None)
     };
-    
+
     log!("Fetching CoinGecko price for: {}", token_id);
 
     // Build URL and headers based on whether we have Pro API key
@@ -130,16 +130,15 @@ fn fetch_coingecko_price(token_input: &str) -> Result<f32> {
 
     // Parse response: {"token-id":{"usd":123.45}}
     let response_json: serde_json::Value = serde_json::from_slice(&response.bytes)?;
-    
+
     // Get the token object
-    let token_data = response_json.get(token_id)
-        .ok_or_else(|| {
-            elog!("Token '{}' not found in CoinGecko response", token_id);
-            anyhow::anyhow!("Token not found")
-        })?;
-    
+    let token_data = response_json.get(token_id).ok_or_else(|| {
+        elog!("Token '{}' not found in CoinGecko response", token_id);
+        anyhow::anyhow!("Token not found")
+    })?;
+
     // Get the USD price
     let price_data: CoinGeckoSimplePrice = serde_json::from_value(token_data.clone())?;
-    
+
     Ok(price_data.usd as f32)
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,42 +11,151 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe("data request execution", () => {
-  it("should aggregate the results from the different APIs", async () => {
-    fetchMock.mockImplementation((url) => {
-      if (url.host === "api.binance.com") {
-        return new Response(JSON.stringify({ price: "2452.30000" }));
-      }
+// Helper function to check results with tolerance for f32 precision issues
+function expectWithinTolerance(result: BigNumber, expected: BigNumber, tolerancePercent: number = 0.1) {
+  const tolerance = expected.multipliedBy(tolerancePercent / 100);
+  const diff = result.minus(expected).abs();
+  if (!diff.isLessThanOrEqualTo(tolerance)) {
+    throw new Error(`Value ${result} is not within ${tolerancePercent}% of ${expected} (diff: ${diff})`);
+  }
+}
 
-      return new Response('Unknown request');
+describe("Binance API", () => {
+  it("should fetch ETH/USDC price from Binance", async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.host === "api.binance.com" && url.searchParams.get("symbol") === "ETHUSDC") {
+        return new Response(JSON.stringify({ price: "2452.30" }));
+      }
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
     });
 
     const oracleProgram = await file(WASM_PATH).arrayBuffer();
-
     const vmResult = await testOracleProgramExecution(
       Buffer.from(oracleProgram),
-      Buffer.from("eth-usdc"),
+      Buffer.from("binance:ETHUSDC"),
       fetchMock
     );
 
     expect(vmResult.exitCode).toBe(0);
-    // BigNumber.js is big endian
     const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
     const result = BigNumber(`0x${hex}`);
-    expect(result).toEqual(BigNumber('2452300032'));
+    expectWithinTolerance(result, BigNumber('2452300000'));
   });
 
-  it('should tally all results in a single data point', async () => {
+  it("should fetch BTC/USDT price from Binance", async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.host === "api.binance.com" && url.searchParams.get("symbol") === "BTCUSDT") {
+        return new Response(JSON.stringify({ price: "42000.50" }));
+      }
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+    });
+
+    const oracleProgram = await file(WASM_PATH).arrayBuffer();
+    const vmResult = await testOracleProgramExecution(
+      Buffer.from(oracleProgram),
+      Buffer.from("binance:BTCUSDT"),
+      fetchMock
+    );
+
+    expect(vmResult.exitCode).toBe(0);
+    const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
+    const result = BigNumber(`0x${hex}`);
+    expectWithinTolerance(result, BigNumber('42000500000'));
+  });
+});
+
+describe("CoinGecko API", () => {
+  it("should fetch EVAA Protocol price", async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.host === "api.coingecko.com" && url.pathname.includes("/simple/price")) {
+        const ids = url.searchParams.get("ids");
+        if (ids === "evaa-protocol") {
+          return new Response(JSON.stringify({ "evaa-protocol": { "usd": 11.34 } }));
+        }
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+
+    const oracleProgram = await file(WASM_PATH).arrayBuffer();
+    const vmResult = await testOracleProgramExecution(
+      Buffer.from(oracleProgram),
+      Buffer.from("evaa-protocol"),
+      fetchMock
+    );
+
+    expect(vmResult.exitCode).toBe(0);
+    const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
+    const result = BigNumber(`0x${hex}`);
+    expectWithinTolerance(result, BigNumber('11340000'));
+  });
+
+  it("should fetch Bitcoin price", async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.host === "api.coingecko.com" && url.pathname.includes("/simple/price")) {
+        const ids = url.searchParams.get("ids");
+        if (ids === "bitcoin") {
+          return new Response(JSON.stringify({ "bitcoin": { "usd": 42000.00 } }));
+        }
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+
+    const oracleProgram = await file(WASM_PATH).arrayBuffer();
+    const vmResult = await testOracleProgramExecution(
+      Buffer.from(oracleProgram),
+      Buffer.from("bitcoin"),
+      fetchMock
+    );
+
+    expect(vmResult.exitCode).toBe(0);
+    const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
+    const result = BigNumber(`0x${hex}`);
+    expectWithinTolerance(result, BigNumber('42000000000'));
+  });
+
+  it("should fetch Ethereum price", async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.host === "api.coingecko.com" && url.pathname.includes("/simple/price")) {
+        const ids = url.searchParams.get("ids");
+        if (ids === "ethereum") {
+          return new Response(JSON.stringify({ "ethereum": { "usd": 2450.75 } }));
+        }
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+
+    const oracleProgram = await file(WASM_PATH).arrayBuffer();
+    const vmResult = await testOracleProgramExecution(
+      Buffer.from(oracleProgram),
+      Buffer.from("ethereum"),
+      fetchMock
+    );
+
+    expect(vmResult.exitCode).toBe(0);
+    const hex = Buffer.from(vmResult.result.toReversed()).toString('hex');
+    const result = BigNumber(`0x${hex}`);
+    expectWithinTolerance(result, BigNumber('2450750000'));
+  });
+});
+
+describe("Tally Phase", () => {
+  it('should aggregate multiple results using median', async () => {
     const oracleProgram = await file(WASM_PATH).arrayBuffer();
 
-    // Result from the execution test
-    let buffer = Buffer.from([0, 33, 43, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-    const vmResult = await testOracleProgramTally(Buffer.from(oracleProgram), Buffer.from('tally-inputs'), [{
-      exitCode: 0,
-      gasUsed: 0,
-      inConsensus: true,
-      result: buffer,
-    }]);
+    // Simulate 3 executors reporting slightly different prices
+    const price1 = Buffer.from([0, 33, 43, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    const price2 = Buffer.from([0, 33, 43, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    const price3 = Buffer.from([0, 33, 43, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+    const vmResult = await testOracleProgramTally(
+      Buffer.from(oracleProgram),
+      Buffer.from(''),
+      [
+        { exitCode: 0, gasUsed: 0, inConsensus: true, result: price1 },
+        { exitCode: 0, gasUsed: 0, inConsensus: true, result: price2 },
+        { exitCode: 0, gasUsed: 0, inConsensus: true, result: price3 },
+      ]
+    );
 
     expect(vmResult.exitCode).toBe(0);
     const hex = Buffer.from(vmResult.result).toString('hex');


### PR DESCRIPTION
## Motivation

Some simplification was required in the default `PriceFeed.sol` contract, to abstract away setup. But to keep it flexible and reusable.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

### Contract Changes Summary

#### New Architecture: `Defaults.sol` + `PriceFeed.sol`

**Created `Defaults.sol`** - Abstract base contract with:
- Constants for gas limits, fees, and replication factor
- `buildRequestInputs()` - Constructs `SedaDataTypes.RequestInputs` with sensible defaults
- Validation helpers (`validateRequest`, `validateFees`, `calculateRequiredFee`)
- Utility functions (`formatPrice`, `_uint2str`)

**Refactored `PriceFeed.sol`** - Simplified destination contract:

1. **Overloaded `transmit()`** functions:
   - `transmit(string token)` - Simple mode, zero fees
   - `transmit(string token, uint256, uint256, uint256)` - Advanced mode with custom fees

2. **New UX functions**:
   - `dryRun(token)` - Pre-flight validation, estimates costs, returns warnings (view function)
   - `isResultReady()` - Non-reverting status check, returns `(ready, consensusReached)`
   - `getFullResult()` - Returns complete `SedaDataTypes.Result` struct for debugging
   - `formatPrice(uint128)` - Converts raw price to "X.XX USD" string

3. **Events & Errors**:
   - `PriceRequested(requestId, token, timestamp)` event
   - Custom errors: `RequestNotTransmitted`, `InsufficientFees`, `InvalidToken`

#### Hardhat Tasks

Created 3  new tasks under `pricefeed` scope:
- `dryrun` - Validate before transmit
- `status` - Check result readiness
- `fullresult` - Debug complete result data

#### Test Suite

Updated tests to:
- Use non-zero `oracleProgramId` (validation now enforces this)
- Call overloaded functions explicitly: `priceFeed['transmit(string)']('evaa-protocol')`

---

### Oracle Program Changes (Minor)

**`execution_phase.rs`**:
- Added prefix-based API selection: `binance:SYMBOL` or defaults to CoinGecko
- Switched CoinGecko to `/simple/price` endpoint
- Added CoinGecko Pro API key support via HTTP headers (`x-cg-pro-api-key`)
- Improved error handling for rate limits and timeouts

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Old tests have been upgraded appropriately.
Will add new tests after a discussion.


## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A

## Commits

- **chore: Fetch pricefeed from coingecko for EVAA**
- **chore: Minor API changes for CG**
- **chore: API adaptation for V2 base**
- **feat: Introduce defaults for Transmit req.body**
- **feat: Introduce DryRun and preflight checks**
- **chore: Apply biome/ts lint fixes**
- **chore: Update readme to include new commands**

